### PR TITLE
Remove LogTrait from AbstractIdentifier

### DIFF
--- a/src/Authentication/Identifier/AbstractIdentifier.php
+++ b/src/Authentication/Identifier/AbstractIdentifier.php
@@ -14,13 +14,11 @@
 namespace Auth\Authentication\Identifier;
 
 use Cake\Core\InstanceConfigTrait;
-use Cake\Log\LogTrait;
 
 abstract class AbstractIdentifier implements IdentifierInterface
 {
 
     use InstanceConfigTrait;
-    use LogTrait;
 
     /**
      * Default configuration


### PR DESCRIPTION
Don't really see the need for it.