### PR TITLE
Fix docblocks

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication;

--- a/src/Authenticator/AbstractAuthenticator.php
+++ b/src/Authenticator/AbstractAuthenticator.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;

--- a/src/Authenticator/AuthenticateInterface.php
+++ b/src/Authenticator/AuthenticateInterface.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;
@@ -23,7 +22,7 @@ interface AuthenticateInterface
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Message\ResponseInterface $response The response.
-     * @return \Cake\Auth\Result
+     * @return \Authentication\ResultInterface
      */
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response);
 }

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -58,7 +58,7 @@ class FormAuthenticator extends AbstractAuthenticator
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
      * @param \Psr\Http\Message\ResponseInterface $response Unused response object.
-     * @return mixed False on login failure.  An array of User data on success.
+     * @return \Authentication\ResultInterface
      */
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response)
     {

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;
@@ -23,21 +22,6 @@ use Psr\Http\Message\ServerRequestInterface;
  * HttpBasic Authenticator
  *
  * Provides Basic HTTP authentication support.
- *
- * ### Using Basic auth
- *
- * You should also set `AuthComponent::$sessionKey = false;` in your AppController's
- * beforeFilter() to prevent CakePHP from sending a session cookie to the client.
- *
- * Since HTTP Basic Authentication is stateless you don't need a login() action
- * in your controller. The user credentials will be checked on each request. If
- * valid credentials are not provided, required authentication headers will be sent
- * by this authentication provider which triggers the login dialog in the browser/client.
- *
- * You may also want to use `$this->Auth->unauthorizedRedirect = false;`.
- * By default, unauthorized users are redirected to the referrer URL,
- * `AuthComponent::$loginAction`, or '/'. If unauthorizedRedirect is set to
- * false, a ForbiddenException exception is thrown instead of redirecting.
  */
 class HttpBasicAuthenticator extends AbstractAuthenticator
 {
@@ -48,7 +32,7 @@ class HttpBasicAuthenticator extends AbstractAuthenticator
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request to authenticate with.
      * @param \Psr\Http\Message\ResponseInterface $response The response to add headers to.
-     * @return mixed Either false on failure, or an array of user data on success.
+     * @return \Authentication\ResultInterface
      */
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response)
     {
@@ -65,7 +49,7 @@ class HttpBasicAuthenticator extends AbstractAuthenticator
      * Get a user based on information in the request. Used by cookie-less auth for stateless clients.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request Request object.
-     * @return mixed Either false or an array of user information
+     * @return bool|\Cake\Datasource\EntityInterface Either false or user entity.
      */
     public function getUser(ServerRequestInterface $request)
     {

--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;
@@ -20,31 +19,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * HttpDigest Authentication adapter for AuthComponent.
+ * HttpDigest Authenticator
  *
- * Provides Digest HTTP authentication support for AuthComponent.
- *
- * ### Using Digest auth
- *
- * ```
- *  $authenticator = new HttpDigestAuthenticator();
- *  $result = $authenticator->authenticate($request);
- *  if ($result->isValid()) {
- *      // Do something with the result
- *  }
- * ```
- *
- * You should also set `AuthComponent::$sessionKey = false;` in your AppController's
- * beforeFilter() to prevent CakePHP from sending a session cookie to the client.
- *
- * Since HTTP Digest Authentication is stateless you don't need a login() action
- * in your controller. The user credentials will be checked on each request. If
- * valid credentials are not provided, required authentication headers will be sent
- * by this authentication provider which triggers the login dialog in the browser/client.
- *
- * You may also want to use `$this->Auth->unauthorizedRedirect = false;`.
- * This causes AuthComponent to throw a ForbiddenException exception instead of
- * redirecting to another page.
+ * Provides Digest HTTP authentication support.
  *
  * ### Generating passwords compatible with Digest authentication.
  *
@@ -59,7 +36,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * it's recommended that you store the digest authentication separately. For
  * example `User.digest_pass` could be used for a digest password, while
  * `User.password` would store the password hash for use with other methods like
- * Basic or Form.
+ * BasicHttp or Form.
  */
 class HttpDigestAuthenticator extends HttpBasicAuthenticator
 {
@@ -97,7 +74,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
      * @param \Psr\Http\Message\ResponseInterface $response Unused response object.
-     * @return mixed False on login failure.  An array of User data on success.
+     * @return \Authentication\ResultInterface
      */
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response)
     {

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;
@@ -44,7 +43,7 @@ class SessionAuthenticator extends AbstractAuthenticator
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request to authenticate with.
      * @param \Psr\Http\Message\ResponseInterface $response The response to add headers to.
-     * @return mixed Either false on failure, or an array of user data on success.
+     * @return \Authentication\ResultInterface
      */
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response)
     {

--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;
@@ -54,7 +53,7 @@ class TokenAuthenticator extends AbstractAuthenticator
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
      * @param \Psr\Http\Message\ResponseInterface $response Unused response object.
-     * @return mixed False on login failure.  An array of User data on success.
+     * @return \Authentication\ResultInterface
      */
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response)
     {

--- a/src/Identifier/AbstractIdentifier.php
+++ b/src/Identifier/AbstractIdentifier.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Identifier;

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Identifier;
@@ -67,7 +66,7 @@ class IdentifierCollection
      * @param string|array $identifier Name of the identifier
      * @param array $config Configuration settings
      * at least the key `className` set to the name of the class to use
-     * @return \Auth\Authentication\Identifier\IdentifierInterface Identifier instance
+     * @return \Authentication\Identifier\IdentifierInterface Identifier instance
      * @throws \RuntimeException If password hasher class not found or
      *   it does not extend Cake\Auth\AbstractPasswordHasher
      */
@@ -115,7 +114,7 @@ class IdentifierCollection
      * @param array $class Name of the identifier
      * at least the key `className` set to the name of the class to use
      * @param array $config Configuration settings
-     * @return \Auth\Authentication\Identifier\IdentifierInterface Identifier instance
+     * @return \Authentication\Identifier\IdentifierInterface Identifier instance
      * @throws \RuntimeException If identifier class not found or
      *   it does not extend Auth\Authentication\Identifier\IdentifierInterface
      */

--- a/src/Identifier/IdentifierInterface.php
+++ b/src/Identifier/IdentifierInterface.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Identifier;

--- a/src/Identifier/OrmIdentifier.php
+++ b/src/Identifier/OrmIdentifier.php
@@ -18,8 +18,7 @@ use Cake\ORM\TableRegistry;
  * ```
  *
  * When configuring OrmIdentifier you can pass in config to which fields,
- * model and additional conditions are used. See FormAuthenticator::$_config
- * for more information.
+ * model and additional conditions are used.
  */
 class OrmIdentifier extends AbstractIdentifier
 {
@@ -45,7 +44,7 @@ class OrmIdentifier extends AbstractIdentifier
      * Identify
      *
      * @param array $data Authentication credentials
-     * @return false|EntityInterface
+     * @return false|\Cake\Datsource\EntityInterface
      */
     public function identify($data)
     {
@@ -70,7 +69,7 @@ class OrmIdentifier extends AbstractIdentifier
      * @param string $username The username/identifier.
      * @param string|null $password The password, if not provided password checking is skipped
      *   and result of find is returned.
-     * @return bool|array Either false on failure, or an array of user data.
+     * @return bool|\Cake\Datsource\EntityInterface Either false on failure, or user data entity.
      */
     protected function _findUser($username, $password = null)
     {

--- a/src/Identifier/TokenIdentifier.php
+++ b/src/Identifier/TokenIdentifier.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Identifier;
@@ -93,7 +92,7 @@ class TokenIdentifier extends AbstractIdentifier
      * Lookup the token in the ORM
      *
      * @param string $token The token string.
-     * @return \Cake\ORM\Query
+     * @return bool|\Cake\Datasource\EntityInterface
      */
     protected function _orm($token)
     {

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Middleware;

--- a/src/PasswordHasher/AbstractPasswordHasher.php
+++ b/src/PasswordHasher/AbstractPasswordHasher.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         2.4.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;

--- a/src/PasswordHasher/DefaultPasswordHasher.php
+++ b/src/PasswordHasher/DefaultPasswordHasher.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;
@@ -41,8 +40,7 @@ class DefaultPasswordHasher extends AbstractPasswordHasher
      * Generates password hash.
      *
      * @param string $password Plain text password to hash.
-     * @return bool|string Password hash or false on failure
-     * @link http://book.cakephp.org/3.0/en/core-libraries/components/authentication.html#hashing-passwords
+     * @return bool|string Password hash or false on failure.
      */
     public function hash($password)
     {

--- a/src/PasswordHasher/FallbackPasswordHasher.php
+++ b/src/PasswordHasher/FallbackPasswordHasher.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;

--- a/src/PasswordHasher/PasswordHasherFactory.php
+++ b/src/PasswordHasher/PasswordHasherFactory.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;
@@ -29,7 +28,7 @@ class PasswordHasherFactory
      *
      * @param string|array $passwordHasher Name of the password hasher or an array with
      * at least the key `className` set to the name of the class to use
-     * @return \Cake\Auth\AbstractPasswordHasher Password hasher instance
+     * @return \Authentication\PasswordHasher\AbstractPasswordHasher Password hasher instance
      * @throws \RuntimeException If password hasher class not found or
      *   it does not extend Cake\Auth\AbstractPasswordHasher
      */

--- a/src/PasswordHasher/PasswordHasherInterface.php
+++ b/src/PasswordHasher/PasswordHasherInterface.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         2.4.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;

--- a/src/Result.php
+++ b/src/Result.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication;

--- a/src/ResultInterface.php
+++ b/src/ResultInterface.php
@@ -8,7 +8,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication;


### PR DESCRIPTION
If fixed param / return types and some obvious issues in description. Also removed `@since` tags,  they can be re-added whenever the plugin is actually merged into core.