### PR TITLE
Allow middlware constructor to accept service config array.

### DIFF
--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -30,10 +30,15 @@ class AuthenticationMiddleware
     /**
      * Constructor
      *
-     * @param \Auth\Authentication\AuthenticatorService $authenticationService Authentication service instance.
+     * @param \Auth\Authentication\AuthenticatorService|array $authenticationService
+     *   Authentication service instance or config array used to create service instance.
      */
-    public function __construct(AuthenticationService $authenticationService)
+    public function __construct($authenticationService)
     {
+        if (is_array($authenticationService)) {
+            $authenticationService = new AuthenticationService($authenticationService);
+        }
+
         $this->_authenticationService = $authenticationService;
     }
 

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -30,8 +30,8 @@ class AuthenticationMiddleware
     /**
      * Constructor
      *
-     * @param \Auth\Authentication\AuthenticatorService|array $authenticationService
-     *   Authentication service instance or config array used to create service instance.
+     * @param \Auth\Authentication\AuthenticatorService|array $authenticationService Authentication service
+     *   instance or config array used to create service instance.
      */
     public function __construct($authenticationService)
     {

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -47,6 +47,29 @@ class AuthenticationMiddlewareTest extends TestCase
     }
 
     /**
+     * testInstanceCreation
+     *
+     * @return void
+     */
+    public function testInstanceCreation()
+    {
+        $middleware = new AuthenticationMiddleware([
+            'identifiers' => [
+                'Authentication.Orm'
+            ],
+            'authenticators' => [
+                'Authentication.Form'
+            ]
+        ]);
+
+        $this->assertAttributeInstanceOf(
+            AuthenticationService::class,
+            '_authenticationService',
+            $middleware
+        );
+    }
+
+    /**
      * testSuccessfulAuthentication
      *
      * @return void


### PR DESCRIPTION
This avoids having to explicity create an authentication service instance
when setting up the middlware in application.