### PR TITLE
Fix a phpstan error

### DIFF
--- a/src/PasswordHasher/WeakPasswordHasher.php
+++ b/src/PasswordHasher/WeakPasswordHasher.php
@@ -40,10 +40,10 @@ class WeakPasswordHasher extends AbstractPasswordHasher
      */
     public function __construct(array $config = [])
     {
+        parent::__construct($config);
         if (Configure::read('debug')) {
             Debugger::checkSecurityKeys();
         }
-        parent::config($config);
     }
 
     /**


### PR DESCRIPTION
Fixes
`Authentication\PasswordHasher\WeakPasswordHasher::__construct() does not call parent constructor from Authentication\PasswordHasher\AbstractPasswordHasher.
`