### PR TITLE
Add missing pass of parameter

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -269,7 +269,7 @@ class AuthenticationService implements AuthenticationServiceInterface
     {
         foreach ($this->_authenticators as $authenticator) {
             if ($authenticator instanceof PersistenceInterface) {
-                $result = $authenticator->persistIdentity($request, $identity);
+                $result = $authenticator->persistIdentity($request, $response, $identity);
                 $request = $result['request'];
                 $response = $result['response'];
             }

--- a/tests/TestCase/AuthenticatorServiceTest.php
+++ b/tests/TestCase/AuthenticatorServiceTest.php
@@ -199,6 +199,7 @@ class AuthenticatorServiceTest extends TestCase
                 'Authentication.Form'
             ]
         ]);
+        $service->loadAuthenticators();
 
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/']


### PR DESCRIPTION
Add the pass of the `$response` parameter, when calling `persistIdentity()` on a `PersistenceInterface` object.