### PR TITLE
Make error messages more consistent.

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -149,7 +149,7 @@ class AuthenticationService implements AuthenticationServiceInterface
         $authenticator = new $className($this->identifiers(), $config);
 
         if (!$authenticator instanceof AuthenticateInterface) {
-            throw new Exception('Authenticator must implement AuthenticateInterface.');
+            throw new Exception('Authenticators must implement AuthenticateInterface.');
         }
 
         if (isset($this->_authenticators)) {
@@ -214,7 +214,7 @@ class AuthenticationService implements AuthenticationServiceInterface
 
         if (empty($this->_authenticators)) {
             throw new RuntimeException(
-                'No authenticator loaded. You need to load at least one authenticator.'
+                'No authenticators loaded. You need to load at least one authenticator.'
             );
         }
 

--- a/src/Authenticator/JwtAuthenticator.php
+++ b/src/Authenticator/JwtAuthenticator.php
@@ -52,7 +52,7 @@ class JwtAuthenticator extends TokenAuthenticator
 
         if (empty($this->_config['secretKey'])) {
             if (!class_exists('Cake\Utility\Security')) {
-                throw new RuntimeException('You must set the `secretKey` config key');
+                throw new RuntimeException('You must set the `secretKey` config key for JWT authentication.');
             }
             $this->setConfig('secretKey', \Cake\Utility\Security::salt());
         }

--- a/src/Identifier/CallbackIdentifier.php
+++ b/src/Identifier/CallbackIdentifier.php
@@ -52,7 +52,7 @@ class CallbackIdentifier extends AbstractIdentifier
 
         if (!is_callable($callback)) {
             throw new InvalidArgumentException(sprintf(
-                'The `callback` option is not a callable but `%s`',
+                'The `callback` option is not a callable. Got `%s` instead.',
                 gettype($callback)
             ));
         }
@@ -74,7 +74,7 @@ class CallbackIdentifier extends AbstractIdentifier
         }
 
         throw new RuntimeException(sprintf(
-            'Invalid return type of `%s`. Must be `%s` or `null`.',
+            'Invalid return type of `%s`. Expecting `%s` or `null`.',
             gettype($result),
             EntityInterface::class
         ));

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -123,12 +123,15 @@ class IdentifierCollection
         $className = App::className($class, 'Identifier', 'Identifier');
 
         if ($className === false) {
-            throw new RuntimeException(sprintf('Identifier class "%s" was not found.', $class));
+            throw new RuntimeException(sprintf('Identifier class `%s` was not found.', $class));
         }
 
         $identifier = new $className($config);
         if (!($identifier instanceof IdentifierInterface)) {
-            throw new RuntimeException(sprintf('Identifier class "%s" must implement \Auth\Authentication\IdentifierInterface', $className));
+            throw new RuntimeException(sprintf(
+                'Identifier class `%s` must implement \Auth\Authentication\IdentifierInterface',
+                $className
+            ));
         }
 
         if (isset($config['alias'])) {

--- a/src/PasswordHasher/PasswordHasherFactory.php
+++ b/src/PasswordHasher/PasswordHasherFactory.php
@@ -45,7 +45,7 @@ class PasswordHasherFactory
 
         $className = App::className($class, 'PasswordHasher', 'PasswordHasher');
         if ($className === false) {
-            throw new RuntimeException(sprintf('Password hasher class "%s" was not found.', $class));
+            throw new RuntimeException(sprintf('Password hasher class `%s` was not found.', $class));
         }
 
         $hasher = new $className($config);

--- a/src/Result.php
+++ b/src/Result.php
@@ -86,7 +86,7 @@ class Result implements ResultInterface
             throw new InvalidArgumentException('Identity can not be empty with status success.');
         }
         if ($identity !== null && !$identity instanceof EntityInterface) {
-            throw new InvalidArgumentException('Identity must be NULL or an object implementing \Cake\Datasource\EntityInterface');
+            throw new InvalidArgumentException('Identity must be `null` or an object implementing \Cake\Datasource\EntityInterface');
         }
 
         $this->_code = (int)$code;

--- a/tests/TestCase/AuthenticatorServiceTest.php
+++ b/tests/TestCase/AuthenticatorServiceTest.php
@@ -120,7 +120,7 @@ class AuthenticatorServiceTest extends TestCase
      * testLoadInvalidAuthenticatorObject
      *
      * @expectedException \Exception
-     * @expectedExceptionMessage Authenticator must implement AuthenticateInterface.
+     * @expectedExceptionMessage Authenticators must implement AuthenticateInterface.
      */
     public function testLoadInvalidAuthenticatorObject()
     {
@@ -257,7 +257,7 @@ class AuthenticatorServiceTest extends TestCase
      * testNoAuthenticatorsLoadedException
      *
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage No authenticator loaded. You need to load at least one authenticator.
+     * @expectedExceptionMessage No authenticators loaded. You need to load at least one authenticator.
      * @return void
      */
     public function testNoAuthenticatorsLoadedException()

--- a/tests/TestCase/Identifier/IdentifierCollectionTest.php
+++ b/tests/TestCase/Identifier/IdentifierCollectionTest.php
@@ -43,7 +43,7 @@ class IdentifierCollectionTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Identifier class "Does-not-exist" was not found.
+     * @expectedExceptionMessage Identifier class `Does-not-exist` was not found.
      */
     public function testLoadException()
     {
@@ -53,7 +53,7 @@ class IdentifierCollectionTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Identifier class "TestApp\Authentication\Identifier\InvalidIdentifier
+     * @expectedExceptionMessage Identifier class `TestApp\Authentication\Identifier\InvalidIdentifier`
      */
     public function testLoadExceptionInterfaceNotImplemented()
     {

--- a/tests/TestCase/PasswordHasher/PasswordHasherFactoryTest.php
+++ b/tests/TestCase/PasswordHasher/PasswordHasherFactoryTest.php
@@ -50,7 +50,7 @@ class PasswordHasherFactoryTest extends TestCase
      * test build() throws exception for non existent hasher
      *
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Password hasher class "FooBar" was not found.
+     * @expectedExceptionMessage Password hasher class `FooBar` was not found.
      * @return void
      */
     public function testBuildException()

--- a/tests/TestCase/ResultTest.php
+++ b/tests/TestCase/ResultTest.php
@@ -42,7 +42,7 @@ class ResultTest extends TestCase
             $this->fail('InvalidArgumentException not thrown!');
         } catch (InvalidArgumentException $e) {
             $result = $e->getMessage();
-            $expected = 'Identity must be NULL or an object implementing \Cake\Datasource\EntityInterface';
+            $expected = 'Identity must be `null` or an object implementing \Cake\Datasource\EntityInterface';
             $this->assertEquals($expected, $result);
         }
     }


### PR DESCRIPTION
* Use plural forms where they should be used.
* Use backticks instead of " for classnames.