### PR TITLE
Fix AuthenticationService::clearIdentity

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -256,7 +256,9 @@ class AuthenticationService implements AuthenticationServiceInterface
     {
         foreach ($this->_authenticators as $authenticator) {
             if ($authenticator instanceof PersistenceInterface) {
-                $response = $authenticator->clearIdentity($request, $response);
+                $result = $authenticator->clearIdentity($request, $response);
+                $request = $result['request'];
+                $response = $result['response'];
             }
         }
 

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -53,6 +53,7 @@ class AuthenticationComponentTest extends TestCase
                 'Authentication.Form'
             ]
         ]);
+        $this->service->loadAuthenticators();
 
         $this->request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/'],


### PR DESCRIPTION
See #77 
The complete return of `$authenticator->clearIdentity($request, $response);` was used as the response, instead of just using the `response` key of the return value.
Also added the missing `$this->service->loadAuthenticators();` to the component test.