### PR TITLE
Cleanup

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -19,7 +19,6 @@ use Authentication\Identifier\IdentifierCollection;
 use Cake\Core\App;
 use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Event\EventDispatcherTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -29,7 +28,6 @@ use RuntimeException;
  */
 class AuthenticationService implements AuthenticationServiceInterface
 {
-    use EventDispatcherTrait;
     use InstanceConfigTrait;
 
     /**

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -216,6 +216,7 @@ class AuthenticationService implements AuthenticationServiceInterface
             );
         }
 
+        $result = null;
         foreach ($this->_authenticators as $authenticator) {
             $result = $authenticator->authenticate($request, $response);
             if ($result->isValid()) {

--- a/src/Authenticator/AbstractAuthenticator.php
+++ b/src/Authenticator/AbstractAuthenticator.php
@@ -13,8 +13,6 @@
 namespace Authentication\Authenticator;
 
 use Authentication\Identifier\IdentifierCollection;
-use Authentication\PasswordHasher\DefaultPasswordHasher;
-use Authentication\PasswordHasher\PasswordHasherTrait;
 use Cake\Core\InstanceConfigTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,7 +21,6 @@ abstract class AbstractAuthenticator implements AuthenticateInterface
 {
 
     use InstanceConfigTrait;
-    use PasswordHasherTrait;
 
     /**
      * Default config for this object.
@@ -43,10 +40,7 @@ abstract class AbstractAuthenticator implements AuthenticateInterface
         'fields' => [
             'username' => 'username',
             'password' => 'password'
-        ],
-        'userModel' => 'Users',
-        'finder' => 'all',
-        'passwordHasher' => DefaultPasswordHasher::class
+        ]
     ];
 
     /**

--- a/src/Authenticator/AbstractAuthenticator.php
+++ b/src/Authenticator/AbstractAuthenticator.php
@@ -25,14 +25,6 @@ abstract class AbstractAuthenticator implements AuthenticateInterface
     /**
      * Default config for this object.
      * - `fields` The fields to use to identify a user by.
-     * - `userModel` The alias for users table, defaults to Users.
-     * - `finder` The finder method to use to fetch user record. Defaults to 'all'.
-     *   You can set finder name as string or an array where key is finder name and value
-     *   is an array passed to `Table::find()` options.
-     *   E.g. ['finderName' => ['some_finder_option' => 'some_value']]
-     * - `passwordHasher` Password hasher class. Can be a string specifying class name
-     *    or an array containing `className` key, any other keys will be passed as
-     *    config to the class. Defaults to 'Default'.
      *
      * @var array
      */
@@ -53,7 +45,7 @@ abstract class AbstractAuthenticator implements AuthenticateInterface
     /**
      * Constructor
      *
-     * @param \Authentication\Identifier\IdentifierCollection $identifiers Array of config to use.
+     * @param \Authentication\Identifier\IdentifierCollection $identifiers Identifiers collection.
      * @param array $config Configuration settings.
      */
     public function __construct(IdentifierCollection $identifiers, array $config = [])

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -87,7 +87,7 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
     /**
      * Generate the login headers
      *
-     * @param \Cake\Network\Request $request Request object.
+     * @param \Psr\Http\Message\ServerRequestInterface $request Request object.
      * @return array Headers for logging in.
      */
     protected function loginHeaders(ServerRequestInterface $request)

--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -192,7 +192,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
      * Generate the login headers
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
-     * @return string Headers for logging in.
+     * @return array Headers for logging in.
      */
     protected function loginHeaders(ServerRequestInterface $request)
     {

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -111,7 +111,7 @@ class IdentifierCollection
     /**
      * Returns identifier object out of a identifier name or a configuration array
      *
-     * @param array $class Name of the identifier
+     * @param string $class Name of the identifier
      * at least the key `className` set to the name of the class to use
      * @param array $config Configuration settings
      * @return \Authentication\Identifier\IdentifierInterface Identifier instance

--- a/src/Identifier/OrmIdentifier.php
+++ b/src/Identifier/OrmIdentifier.php
@@ -3,7 +3,7 @@ namespace Authentication\Identifier;
 
 use Authentication\PasswordHasher\DefaultPasswordHasher;
 use Authentication\PasswordHasher\PasswordHasherTrait;
-use Cake\Datasource\EntityInterface;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -23,6 +23,7 @@ use Cake\ORM\TableRegistry;
 class OrmIdentifier extends AbstractIdentifier
 {
 
+    use LocatorAwareTrait;
     use PasswordHasherTrait;
 
     /**
@@ -104,7 +105,7 @@ class OrmIdentifier extends AbstractIdentifier
     protected function _query($identifier)
     {
         $config = $this->_config;
-        $table = TableRegistry::get($config['userModel']);
+        $table = $this->tableLocator()->get($config['userModel']);
 
         $options = ['conditions' => $this->_buildConditions($identifier, $table)];
 

--- a/src/Identifier/OrmIdentifier.php
+++ b/src/Identifier/OrmIdentifier.php
@@ -4,7 +4,6 @@ namespace Authentication\Identifier;
 use Authentication\PasswordHasher\DefaultPasswordHasher;
 use Authentication\PasswordHasher\PasswordHasherTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
-use Cake\ORM\TableRegistry;
 
 /**
  * CakePHP ORM Identifier
@@ -27,7 +26,16 @@ class OrmIdentifier extends AbstractIdentifier
     use PasswordHasherTrait;
 
     /**
-     * Default configuration
+     * Default configuration.
+     * - `fields` The fields to use to identify a user by.
+     * - `userModel` The alias for users table, defaults to Users.
+     * - `finder` The finder method to use to fetch user record. Defaults to 'all'.
+     *   You can set finder name as string or an array where key is finder name and value
+     *   is an array passed to `Table::find()` options.
+     *   E.g. ['finderName' => ['some_finder_option' => 'some_value']]
+     * - `passwordHasher` Password hasher class. Can be a string specifying class name
+     *    or an array containing `className` key, any other keys will be passed as
+     *    config to the class. Defaults to 'Default'.
      *
      * @var array
      */

--- a/src/PasswordHasher/PasswordHasherFactory.php
+++ b/src/PasswordHasher/PasswordHasherFactory.php
@@ -13,7 +13,6 @@
  */
 namespace Authentication\PasswordHasher;
 
-use Authentication\PasswordHasher\AbstractPasswordHasher;
 use Authentication\PasswordHasher\PasswordHasherInterface;
 use Cake\Core\App;
 use RuntimeException;
@@ -28,7 +27,7 @@ class PasswordHasherFactory
      *
      * @param string|array $passwordHasher Name of the password hasher or an array with
      * at least the key `className` set to the name of the class to use
-     * @return \Authentication\PasswordHasher\AbstractPasswordHasher Password hasher instance
+     * @return \Authentication\PasswordHasher\PasswordHasherInterface Password hasher instance
      * @throws \RuntimeException If password hasher class not found or
      *   it does not extend Cake\Auth\AbstractPasswordHasher
      */


### PR DESCRIPTION
- Removed unnecessary use statements.
- Removed password hasher dependency from `Authenticator` as it is not required nor used there.
- Use TableLocator instead of TableRegistry.
- Docblock cleanup (some issues found with phpstan).