### PR TITLE
LdapIdentifier fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,14 @@
     "require-dev": {
         "cakephp/cakephp": "~3.4",
         "cakephp/cakephp-codesniffer": "^2.1",
-        "cakephp/event": "~3.4",
-        "cakephp/utility": "~3.4",
         "phpunit/phpunit": "<6.0",
         "firebase/php-jwt": "~4.0"
     },
     "suggest": {
-        "cakephp/orm": "To use \"OrmIdentifier\" (Not needed separately if using full CakePHP framework).",
+        "cakephp/orm": "To use \"OrmResolver\" (Not needed separately if using full CakePHP framework).",
         "firebase/php-jwt": "If you want to use the JWT adapter add this dependency",
-        "ext-ldap": "Make sure this php extension is installed and enabled on your system if you want to use the built-in LDAP class.",
-        "cakephp/utility": "Provides CakePHP security methods. Required for the JWT and Legacy adapter."
+        "ext-ldap": "Make sure this php extension is installed and enabled on your system if you want to use the built-in LDAP adapter for \"LdapIdentifier\".",
+        "cakephp/utility": "Provides CakePHP security methods. Required for the JWT adapter and Legacy password hasher."
     },
     "license": "MIT",
     "minimum-stability": "stable",

--- a/src/Identifier/LdapIdentifier.php
+++ b/src/Identifier/LdapIdentifier.php
@@ -15,8 +15,6 @@ namespace Authentication\Identifier;
 use Authentication\Identifier\Ldap\AdapterInterface;
 use Authentication\Identifier\Ldap\ExtensionAdapter;
 use Cake\Core\App;
-use Cake\Core\Exception\Exception;
-use Cake\Network\Exception\InternalErrorException;
 use Cake\ORM\Entity;
 use ErrorException;
 use InvalidArgumentException;
@@ -122,7 +120,8 @@ class LdapIdentifier extends AbstractIdentifier
         }
 
         if (!($ldap instanceof AdapterInterface)) {
-            throw new RuntimeException('Option `ldap` must implement Authentication\Identifier\Backend\LdapInterface.');
+            $message = sprintf('Option `ldap` must implement `%s`.', LdapIdentifier::class);
+            throw new RuntimeException($message);
         }
 
         $this->_ldap = $ldap;
@@ -150,7 +149,6 @@ class LdapIdentifier extends AbstractIdentifier
      * Initializes the LDAP connection
      *
      * @return void
-     * @throws \Cake\Network\Exception\InternalErrorException Raised in case of an unsucessful connection.
      */
     protected function _connectLdap()
     {

--- a/src/Identifier/LdapIdentifier.php
+++ b/src/Identifier/LdapIdentifier.php
@@ -12,10 +12,10 @@
  */
 namespace Authentication\Identifier;
 
+use ArrayObject;
 use Authentication\Identifier\Ldap\AdapterInterface;
 use Authentication\Identifier\Ldap\ExtensionAdapter;
 use Cake\Core\App;
-use Cake\ORM\Entity;
 use ErrorException;
 use InvalidArgumentException;
 use RuntimeException;
@@ -131,7 +131,7 @@ class LdapIdentifier extends AbstractIdentifier
      * Identify
      *
      * @param array $data Authentication credentials
-     * @return \Cake\Datasource\EntityInterface|null
+     * @return \ArrayAccess|null
      */
     public function identify($data)
     {
@@ -166,7 +166,7 @@ class LdapIdentifier extends AbstractIdentifier
      *
      * @param string $username The username
      * @param string $password The password
-     * @return \Cake\Datasource\EntityInterface|null
+     * @return \ArrayAccess|null
      */
     protected function _bindUser($username, $password)
     {
@@ -176,7 +176,7 @@ class LdapIdentifier extends AbstractIdentifier
             if ($ldapBind === true) {
                 $this->_ldap->unbind();
 
-                return new Entity([
+                return new ArrayObject([
                     $config['fields']['username'] => $username
                 ]);
             }

--- a/src/Identifier/LdapIdentifier.php
+++ b/src/Identifier/LdapIdentifier.php
@@ -120,7 +120,7 @@ class LdapIdentifier extends AbstractIdentifier
         }
 
         if (!($ldap instanceof AdapterInterface)) {
-            $message = sprintf('Option `ldap` must implement `%s`.', LdapIdentifier::class);
+            $message = sprintf('Option `ldap` must implement `%s`.', AdapterInterface::class);
             throw new RuntimeException($message);
         }
 

--- a/src/Identifier/LdapIdentifier.php
+++ b/src/Identifier/LdapIdentifier.php
@@ -146,6 +146,16 @@ class LdapIdentifier extends AbstractIdentifier
     }
 
     /**
+     * Returns configured LDAP adapter.
+     *
+     * @return \Authentication\Identifier\Ldap\AdapterInterface
+     */
+    public function getAdapter()
+    {
+        return $this->_ldap;
+    }
+
+    /**
      * Initializes the LDAP connection
      *
      * @return void

--- a/tests/TestCase/Identifier/LdapIdentifierTest.php
+++ b/tests/TestCase/Identifier/LdapIdentifierTest.php
@@ -12,23 +12,16 @@
  */
 namespace Authentication\Test\TestCase\Identifier;
 
-use Authentication\Identifier\LdapIdentifier;
+use ArrayAccess;
 use Authentication\Identifier\Ldap\AdapterInterface;
+use Authentication\Identifier\Ldap\ExtensionAdapter;
+use Authentication\Identifier\LdapIdentifier;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
-use Cake\Datasource\EntityInterface;
 use ErrorException;
+use stdClass;
 
 class LdapIdentifierTest extends TestCase
 {
-
-    /**
-     * {@inheritDoc}
-     */
-    public function setUp()
-    {
-        parent::setUp();
-        $this->skipIf(!extension_loaded('ldap'), 'LDAP extension is not loaded');
-    }
 
     /**
      * testIdentify
@@ -37,19 +30,28 @@ class LdapIdentifierTest extends TestCase
      */
     public function testIdentify()
     {
+        $host = 'ldap.example.com';
+        $bind = function ($username) {
+            return 'cn=' . $username . ',dc=example,dc=com';
+        };
+        $options = [
+            'foo' => 3
+        ];
+
         $ldap = $this->createMock(AdapterInterface::class);
-        $ldap->method('bind')
+        $ldap->expects($this->once())
+            ->method('connect')
+            ->with($host, 389, $options);
+        $ldap->expects($this->once())
+            ->method('bind')
+            ->with('cn=john,dc=example,dc=com', 'doe')
             ->willReturn(true);
 
         $identifier = new LdapIdentifier([
-            'host' => 'ldap.example.com',
-            'bindDN' => function () {
-                return 'dc=example,dc=com';
-            },
+            'host' => $host,
+            'bindDN' => $bind,
             'ldap' => $ldap,
-            'options' => [
-                LDAP_OPT_PROTOCOL_VERSION => 3
-            ]
+            'options' => $options
         ]);
 
         $result = $identifier->identify([
@@ -57,22 +59,7 @@ class LdapIdentifierTest extends TestCase
             'password' => 'doe'
         ]);
 
-        $this->assertInstanceOf(EntityInterface::class, $result);
-    }
-
-    /**
-     * testNoLdapOptionSet
-     *
-     * @return void
-     */
-    public function testNoLdapOptionSet()
-    {
-        $identifier = new LdapIdentifier([
-            'host' => 'ldap.example.com',
-            'bindDN' => function () {
-                return 'dc=example,dc=com';
-            }
-        ]);
+        $this->assertInstanceOf(ArrayAccess::class, $result);
     }
 
     /**
@@ -98,10 +85,29 @@ class LdapIdentifierTest extends TestCase
             'username' => 'john',
             'password' => 'doe'
         ]);
-        $this->assertSame(null, $result);
+        $this->assertNull($result);
 
         $resultTwo = $identifier->identify(null);
-        $this->assertSame(null, $result);
+        $this->assertNull($resultTwo);
+    }
+
+    /**
+     * testLdapExtensionAdapter
+     *
+     * @return void
+     */
+    public function testLdapExtensionAdapter()
+    {
+        $this->skipIf(!extension_loaded('ldap'), 'LDAP extension is not loaded.');
+
+        $identifier = new LdapIdentifier([
+            'host' => 'ldap.example.com',
+            'bindDN' => function () {
+                return 'dc=example,dc=com';
+            }
+        ]);
+
+        $this->assertInstanceOf(ExtensionAdapter::class, $identifier->getAdapter());
     }
 
     /**
@@ -109,11 +115,11 @@ class LdapIdentifierTest extends TestCase
      *
      * @return void
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Option `ldap` must implement Authentication\Identifier\Backend\LdapInterface.
+     * @expectedExceptionMessage Option `ldap` must implement `Authentication\Identifier\Ldap\AdapterInterface`.
      */
     public function testWrongLdapObject()
     {
-        $notLdap = new \stdClass;
+        $notLdap = new stdClass;
 
         $identifier = new LdapIdentifier([
             'host' => 'ldap.example.com',

--- a/tests/TestCase/Identifier/LdapIdentifierTest.php
+++ b/tests/TestCase/Identifier/LdapIdentifierTest.php
@@ -13,9 +13,9 @@
 namespace Authentication\Test\TestCase\Identifier;
 
 use ArrayAccess;
+use Authentication\Identifier\LdapIdentifier;
 use Authentication\Identifier\Ldap\AdapterInterface;
 use Authentication\Identifier\Ldap\ExtensionAdapter;
-use Authentication\Identifier\LdapIdentifier;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use ErrorException;
 use stdClass;


### PR DESCRIPTION
- Identifier returns `ArrayObject` instead of `Entity` (since `cakephp/orm` is optional).
- Tests no longer depend on LDAP extension apart from the one with default setup.
- Make sure `LdapIdentifier::identify()` calls adapter methods correctly.
- Some messages has been fixed.