### PR TITLE
Add array type hint to IdentifierInterface::identify

### DIFF
--- a/src/Identifier/CallbackIdentifier.php
+++ b/src/Identifier/CallbackIdentifier.php
@@ -64,7 +64,7 @@ class CallbackIdentifier extends AbstractIdentifier
      * @param array $data Authentication credentials
      * @return \ArrayAccess|null
      */
-    public function identify($data)
+    public function identify(array $data)
     {
         $callback = $this->getConfig('callback');
 

--- a/src/Identifier/IdentifierInterface.php
+++ b/src/Identifier/IdentifierInterface.php
@@ -18,10 +18,10 @@ interface IdentifierInterface
     /**
      * Identifies an user or service by the passed credentials
      *
-     * @param mixed $credentials Authentication credentials
+     * @param array $credentials Authentication credentials
      * @return \ArrayAccess|null
      */
-    public function identify($credentials);
+    public function identify(array $credentials);
 
     /**
      * Gets a list of errors happened in the identification process

--- a/src/Identifier/LdapIdentifier.php
+++ b/src/Identifier/LdapIdentifier.php
@@ -133,7 +133,7 @@ class LdapIdentifier extends AbstractIdentifier
      * @param array $data Authentication credentials
      * @return \ArrayAccess|null
      */
-    public function identify($data)
+    public function identify(array $data)
     {
         $this->_connectLdap();
         $fields = $this->getConfig('fields');

--- a/src/Identifier/PasswordIdentifier.php
+++ b/src/Identifier/PasswordIdentifier.php
@@ -89,7 +89,7 @@ class PasswordIdentifier extends AbstractIdentifier
      * @param array $data Authentication credentials.
      * @return \ArrayAccess|null
      */
-    public function identify($data)
+    public function identify(array $data)
     {
         $fields = $this->getConfig('fields');
 

--- a/src/Identifier/TokenIdentifier.php
+++ b/src/Identifier/TokenIdentifier.php
@@ -39,7 +39,7 @@ class TokenIdentifier extends AbstractIdentifier
      * @param array $data Authentication credentials.
      * @return \ArrayAccess|null
      */
-    public function identify($data)
+    public function identify(array $data)
     {
         $dataField = $this->getConfig('dataField');
         if (!isset($data[$dataField])) {

--- a/tests/TestCase/Identifier/LdapIdentifierTest.php
+++ b/tests/TestCase/Identifier/LdapIdentifierTest.php
@@ -63,11 +63,11 @@ class LdapIdentifierTest extends TestCase
     }
 
     /**
-     * testIdentifyNull
+     * testIdentifyMissingCredentials
      *
      * @return void
      */
-    public function testIdentifyNull()
+    public function testIdentifyMissingCredentials()
     {
         $ldap = $this->createMock(AdapterInterface::class);
         $ldap->method('bind')
@@ -87,7 +87,7 @@ class LdapIdentifierTest extends TestCase
         ]);
         $this->assertNull($result);
 
-        $resultTwo = $identifier->identify(null);
+        $resultTwo = $identifier->identify([]);
         $this->assertNull($resultTwo);
     }
 


### PR DESCRIPTION
`array_intersect_key ` will trigger a warning if the `$data` argument is not an array.