### PR TITLE
Use constant time comparision

### DIFF
--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -100,7 +100,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
         }
 
         $hash = $this->generateResponseHash($digest, $password, $server['ORIGINAL_REQUEST_METHOD']);
-        if (hash_equals($digest['response'], $hash)) {
+        if (hash_equals($hash, $digest['response'])) {
             return new Result($user, Result::SUCCESS);
         }
 

--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -100,7 +100,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
         }
 
         $hash = $this->generateResponseHash($digest, $password, $server['ORIGINAL_REQUEST_METHOD']);
-        if ($digest['response'] === $hash) {
+        if (hash_equals($digest['response'], $hash)) {
             return new Result($user, Result::SUCCESS);
         }
 


### PR DESCRIPTION
Prevent timing attacks by using a constant time comparison.

Port of cakephp/cakephp#11096