### PR TITLE
Updating DigestAuthenticator to match CakePHP core updates.

### DIFF
--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -47,7 +47,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
      * HttpDigestAuthenticate uses the following extra keys:
      *
      * - `realm` The realm authentication is for, Defaults to the servername.
-     * - `nonce` A nonce used for authentication. Defaults to `uniqid()`.
+     * - `nonceLifetime` The number of seconds that nonces are valid for. Defaults to 300.
      * - `qop` Defaults to 'auth', no other values are supported at this time.
      * - `opaque` A string that must be returned unchanged by clients.
      *    Defaults to `md5($config['realm'])`
@@ -60,7 +60,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
         $this->setConfig([
             'realm' => null,
             'qop' => 'auth',
-            'nonce' => uniqid(''),
+            'nonceLifetime' => 300,
             'opaque' => null,
         ]);
 
@@ -88,6 +88,10 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
 
         if (empty($user)) {
             return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
+        }
+
+        if (!$this->validNonce($digest['nonce'])) {
+            return new Result(null, Result::FAILURE_CREDENTIAL_INVALID);
         }
 
         $field = $this->_config['fields']['password'];
@@ -201,15 +205,65 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
         $options = [
             'realm' => $realm,
             'qop' => $this->_config['qop'],
-            'nonce' => $this->_config['nonce'],
+            'nonce' => $this->generateNonce(),
             'opaque' => $this->_config['opaque'] ?: md5($realm)
         ];
 
+        $digest = $this->_getDigest($request);
+        if ($digest && isset($digest['nonce']) && !$this->validNonce($digest['nonce'])) {
+            $options['stale'] = true;
+        }
+
         $opts = [];
         foreach ($options as $k => $v) {
-            $opts[] = sprintf('%s="%s"', $k, $v);
+            if (is_bool($v)) {
+                $v = $v ? 'true' : 'false';
+                $opts[] = sprintf('%s=%s', $k, $v);
+            } else {
+                $opts[] = sprintf('%s="%s"', $k, $v);
+            }
         }
 
         return ['WWW-Authenticate' => 'Digest ' . implode(',', $opts)];
+    }
+
+    /**
+     * Generate a nonce value that is validated in future requests.
+     *
+     * @return string
+     */
+    protected function generateNonce()
+    {
+        $expiryTime = microtime(true) + $this->getConfig('nonceLifetime');
+        $secret = $this->getConfig('secret');
+        $signatureValue = hash_hmac('sha1', $expiryTime . ':' . $secret, $secret);
+        $nonceValue = $expiryTime . ':' . $signatureValue;
+
+        return base64_encode($nonceValue);
+    }
+
+    /**
+     * Check the nonce to ensure it is valid and not expired.
+     *
+     * @param string $nonce The nonce value to check.
+     * @return bool
+     */
+    protected function validNonce($nonce)
+    {
+        $value = base64_decode($nonce);
+        if ($value === false) {
+            return false;
+        }
+        $parts = explode(':', $value);
+        if (count($parts) !== 2) {
+            return false;
+        }
+        list($expires, $checksum) = $parts;
+        if ($expires < microtime(true)) {
+            return false;
+        }
+        $secret = $this->getConfig('secret');
+
+        return hash_hmac('sha1', $expires . ':' . $secret, $secret) === $checksum;
     }
 }

--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -263,7 +263,8 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
             return false;
         }
         $secret = $this->getConfig('secret');
+        $check = hash_hmac('sha1', $expires . ':' . $secret, $secret);
 
-        return hash_hmac('sha1', $expires . ':' . $secret, $secret) === $checksum;
+        return hash_equals($check, $checksum);
     }
 }

--- a/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
@@ -15,9 +15,9 @@
  */
 namespace Authentication\Test\TestCase\Authentication;
 
-use Authentication\Authenticator\StatelessInterface;
 use Authentication\Authenticator\HttpDigestAuthenticator;
 use Authentication\Authenticator\Result;
+use Authentication\Authenticator\StatelessInterface;
 use Authentication\Authenticator\UnauthorizedException;
 use Authentication\Identifier\IdentifierCollection;
 use Cake\Core\Configure;


### PR DESCRIPTION
Shore up some of the implementation gaps we have around nonces. Nonces should expire and should be generated by the server. I've followed the Symfony approach to generating nonces which results in short lived (5 minutes by default) nonces that are regenerated each time the client receives a 401.

By validating and requiring nonce rotation we can avoid replay attacks with our Digest authentication implementation. This replicates changes made in cakephp/cakephp#9668

Adopt constant time string comparisons to prevent timing attacks.