### PR TITLE
Fire Authentication.afterIdentify in beforeFilter.

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -63,8 +63,6 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
         }
 
         $this->eventManager($controller->eventManager());
-
-        $this->_afterIdentify();
     }
 
     /**
@@ -72,7 +70,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      *
      * @return void
      */
-    protected function _afterIdentify()
+    public function beforeFilter()
     {
         $provider = $this->_authentication->getAuthenticationProvider();
 

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -229,8 +229,8 @@ class AuthenticationComponentTest extends TestCase
         $this->request = $this->request->withAttribute('authentication', $this->service);
 
         $controller = new Controller($this->request, $this->response);
-        $registry = new ComponentRegistry($controller);
-        new AuthenticationComponent($registry);
+        $controller->loadComponent('Authentication.Authentication');
+        $controller->startupProcess();
 
         $this->assertInstanceOf(Event::class, $result);
         $this->assertEquals('Authentication.afterIdentify', $result->name());


### PR DESCRIPTION
The event was fired in the controller construction time, before any 
listener had a chance to be attached to the controller.