### PR TITLE
Add VerificationIdentifier

### DIFF
--- a/src/Identifier/VerificationIdentifier.php
+++ b/src/Identifier/VerificationIdentifier.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authentication\Identifier;
+
+use Authentication\Identifier\Resolver\ResolverAwareTrait;
+
+/**
+ * Identity verification identifier
+ */
+class VerificationIdentifier extends AbstractIdentifier
+{
+
+    use ResolverAwareTrait;
+
+    /**
+     * Default configuration.
+     * - `fields` A list of fields used for verification.
+     * - `resolver` Identity resolver to use.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'fields' => [
+            'id' => 'id'
+        ],
+        'resolver' => 'Authentication.Orm'
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function identify(array $data)
+    {
+        $conditions = [];
+        foreach ($this->getConfig('fields') as $key => $field) {
+            if (!isset($data[$key])) {
+                return null;
+            }
+            $conditions[$field] = $data[$key];
+        }
+
+        return $this->getResolver()->find($conditions);
+    }
+}

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -43,7 +43,7 @@ class SessionAuthenticatorTest extends TestCase
         parent::setUp();
 
         $this->identifiers = new IdentifierCollection([
-           'Authentication.Password'
+           'Authentication.Verification'
         ]);
 
         $this->sessionMock = $this->getMockBuilder('\Cake\Network\Session')
@@ -106,8 +106,9 @@ class SessionAuthenticatorTest extends TestCase
             ->method('read')
             ->with('Auth')
             ->will($this->returnValue([
+                'id' => 1,
                 'username' => 'mariano',
-                'password' => 'password'
+                'password' => 'h4s5ed'
             ]));
 
         $request = $request->withAttribute('session', $this->sessionMock);
@@ -124,6 +125,7 @@ class SessionAuthenticatorTest extends TestCase
             ->method('read')
             ->with('Auth')
             ->will($this->returnValue([
+                'id' => 1000,
                 'username' => 'does-not',
                 'password' => 'exist'
             ]));

--- a/tests/TestCase/Identifier/VerificationIdentifierTest.php
+++ b/tests/TestCase/Identifier/VerificationIdentifierTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authentication\Test\TestCase\Identifier;
+
+use ArrayObject;
+use Authentication\Identifier\Resolver\ResolverInterface;
+use Authentication\Identifier\VerificationIdentifier;
+use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
+
+class VerificationIdentifierTest extends TestCase
+{
+
+    /**
+     * testIdentify
+     *
+     * @return void
+     */
+    public function testIdentify()
+    {
+        $resolver = $this->createMock(ResolverInterface::class);
+
+        $identifier = new VerificationIdentifier([
+            'fields' => [
+                'id' => 'user_id'
+            ]
+        ]);
+        $identifier->setResolver($resolver);
+
+        $user = new ArrayObject([
+            'user_id' => 1
+        ]);
+
+        $resolver->expects($this->once())
+            ->method('find')
+            ->with([
+                'user_id' => 1
+            ])
+            ->willReturn($user);
+
+        $result = $identifier->identify(['id' => 1]);
+        $this->assertSame($user, $result);
+    }
+
+    /**
+     * testIdentifyMissingData
+     *
+     * @return void
+     */
+    public function testIdentifyMissingData()
+    {
+        $resolver = $this->createMock(ResolverInterface::class);
+
+        $identifier = new VerificationIdentifier();
+        $identifier->setResolver($resolver);
+
+        $resolver->expects($this->never())
+            ->method('find');
+
+        $result = $identifier->identify(['user' => 'larry']);
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
This is a identifier which can be used by authenticators that implement `PersistenceInterface` (Session, Cookie) in order to verify that the persisted identity is still valid.

Fix attempt for #150