### PR TITLE
Change authenticator dependency from IdentifierCollection to IdentifierInterface

### DIFF
--- a/src/Authenticator/AbstractAuthenticator.php
+++ b/src/Authenticator/AbstractAuthenticator.php
@@ -12,7 +12,6 @@
  */
 namespace Authentication\Authenticator;
 
-use Authentication\Identifier\IdentifierCollection;
 use Authentication\Identifier\IdentifierInterface;
 use Cake\Core\InstanceConfigTrait;
 use Psr\Http\Message\ResponseInterface;
@@ -37,32 +36,45 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface
     ];
 
     /**
-     * Identifier collection
+     * Identifier or identifiers collection.
      *
-     * @var \Authentication\Identifier\IdentifierCollection
+     * @var \Authentication\Identifier\IdentifierInterface
      */
-    protected $_identifiers;
+    protected $_identifier;
 
     /**
      * Constructor
      *
-     * @param \Authentication\Identifier\IdentifierCollection $identifiers Identifiers collection.
+     * @param \Authentication\Identifier\IdentifierInterface $identifier Identifier or identifiers collection.
      * @param array $config Configuration settings.
      */
-    public function __construct(IdentifierCollection $identifiers, array $config = [])
+    public function __construct(IdentifierInterface $identifier, array $config = [])
     {
         $this->setConfig($config);
-        $this->_identifiers = $identifiers;
+        $this->_identifier = $identifier;
     }
 
     /**
-     * Gets the identifier collection
+     * Gets the identifier.
      *
-     * @return \Authentication\Identifier\IdentifierCollection
+     * @return \Authentication\Identifier\IdentifierInterface
      */
-    public function identifiers()
+    public function getIdentifier()
     {
-        return $this->_identifiers;
+        return $this->_identifier;
+    }
+
+    /**
+     * Sets the identifier.
+     *
+     * @param \Authentication\Identifier\IdentifierInterface $identifier IdentifierInterface instance.
+     * @return $this
+     */
+    public function setIdentifier(IdentifierInterface $identifier)
+    {
+        $this->_identifier = $identifier;
+
+        return $this;
     }
 
     /**

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -103,10 +103,10 @@ class FormAuthenticator extends AbstractAuthenticator
             ]);
         }
 
-        $user = $this->identifiers()->identify($data);
+        $user = $this->_identifier->identify($data);
 
         if (empty($user)) {
-            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->identifiers()->getErrors());
+            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
         }
 
         return new Result($user, Result::SUCCESS);

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -64,7 +64,7 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
             return null;
         }
 
-        return $this->identifiers()->identify([
+        return $this->_identifier->identify([
             IdentifierInterface::CREDENTIAL_USERNAME => $username,
             IdentifierInterface::CREDENTIAL_PASSWORD => $password
         ]);

--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -13,7 +13,6 @@
  */
 namespace Authentication\Authenticator;
 
-use Authentication\Identifier\IdentifierCollection;
 use Authentication\Identifier\IdentifierInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -53,10 +52,10 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
      * - `opaque` A string that must be returned unchanged by clients.
      *    Defaults to `md5($config['realm'])`
      *
-     * @param \Authentication\Identifier\IdentifierCollection $identifiers Array of config to use.
+     * @param \Authentication\Identifier\IdentifierInterface $identifier Identifier instance.
      * @param array $config Configuration settings.
      */
-    public function __construct(IdentifierCollection $identifiers, array $config = [])
+    public function __construct(IdentifierInterface $identifier, array $config = [])
     {
         $this->setConfig([
             'realm' => null,
@@ -66,7 +65,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
         ]);
 
         $this->setConfig($config);
-        parent::__construct($identifiers, $config);
+        parent::__construct($identifier, $config);
     }
 
     /**
@@ -83,8 +82,8 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
             return new Result(null, Result::FAILURE_OTHER);
         }
 
-        $user = $this->identifiers()->identify([
-            IdentifierInterface::CREDENTIAL_USERNAME => $digest['username'],
+        $user = $this->_identifier->identify([
+            IdentifierInterface::CREDENTIAL_USERNAME => $digest['username']
         ]);
 
         if (empty($user)) {

--- a/src/Authenticator/JwtAuthenticator.php
+++ b/src/Authenticator/JwtAuthenticator.php
@@ -13,7 +13,6 @@
 namespace Authentication\Authenticator;
 
 use ArrayObject;
-use Authentication\Identifier\IdentifierCollection;
 use Authentication\Identifier\IdentifierInterface;
 use Exception;
 use Firebase\JWT\JWT;
@@ -47,9 +46,9 @@ class JwtAuthenticator extends TokenAuthenticator
     /**
      * {@inheritDoc}
      */
-    public function __construct(IdentifierCollection $identifiers, array $config = [])
+    public function __construct(IdentifierInterface $identifier, array $config = [])
     {
-        parent::__construct($identifiers, $config);
+        parent::__construct($identifier, $config);
 
         if (empty($this->_config['secretKey'])) {
             if (!class_exists('Cake\Utility\Security')) {
@@ -99,12 +98,12 @@ class JwtAuthenticator extends TokenAuthenticator
             return new Result($user, Result::SUCCESS);
         }
 
-        $user = $this->identifiers()->identify([
+        $user = $this->_identifier->identify([
             $key => $result[$key]
         ]);
 
         if (empty($user)) {
-            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->identifiers()->getErrors());
+            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
         }
 
         return new Result($user, Result::SUCCESS);

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -63,7 +63,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
             foreach ($this->getConfig('fields') as $key => $field) {
                 $credentials[$key] = $user[$field];
             }
-            $user = $this->identifiers()->identify($credentials);
+            $user = $this->_identifier->identify($credentials);
 
             if (empty($user)) {
                 return new Result(null, Result::FAILURE_CREDENTIAL_INVALID);

--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -119,12 +119,12 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
             return new Result(null, Result::FAILURE_OTHER);
         }
 
-        $user = $this->identifiers()->identify([
+        $user = $this->_identifier->identify([
             IdentifierInterface::CREDENTIAL_TOKEN => $token
         ]);
 
         if (empty($user)) {
-            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->identifiers()->getErrors());
+            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
         }
 
         return new Result($user, Result::SUCCESS);

--- a/tests/TestCase/Authenticator/AbstractAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/AbstractAuthenticatorTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authentication\Test\TestCase\Authenticator;
+
+use Authentication\Authenticator\AbstractAuthenticator;
+use Authentication\Identifier\IdentifierInterface;
+use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
+
+class AbstractAuthenticatorTest extends TestCase
+{
+
+    /**
+     * testGetIdentifier
+     *
+     * @return void
+     */
+    public function testGetIdentifier()
+    {
+        $identifier = $this->createMock(IdentifierInterface::class);
+        $authenticator = $this->getMockForAbstractClass(AbstractAuthenticator::class, [$identifier]);
+
+        $this->assertSame($identifier, $authenticator->getIdentifier());
+    }
+
+    /**
+     * testSetIdentifier
+     *
+     * @return void
+     */
+    public function testSetIdentifier()
+    {
+        $authenticator = $this->getMockForAbstractClass(AbstractAuthenticator::class, [], '', false);
+
+        $identifier = $this->createMock(IdentifierInterface::class);
+        $authenticator->setIdentifier($identifier);
+
+        $this->assertSame($identifier, $authenticator->getIdentifier());
+    }
+}


### PR DESCRIPTION
Since `IdentifierCollection` implements `IdentifierInterface` I changed authenticators constructor to accept instances of identifier interface, not only the collection. This allows for building custom authenticators that rely on a specific identifier making some of them more secure if necessary.

By default all authenticators will use service's collection but a specific authenticator's `IdentifierInterface` dependency can be swapped if necessary.

For example:
```php
$form = $service->loadAuthenticator('Form');
$form->getIdentifier(); // IdentifierCollection, the same instance as $service->identifiers()

//using setter injection
$password = $service->loadIdentifier('Password');
$form = $service
    ->loadAuthenticator('Form')
    ->setIdentifier($password);
$form->getIdentifier(); // PasswordIdentifier

//building custom authenticator
$form = new FormAuthenticator(new PasswordIdentifier);
$service->authenticators()->set('Form', $form);

//or
$collection = new IdentifierCollection(['Foo', 'Bar']);
$form = new FormAuthenticator($collection);
$service->authenticators()->set('Form', $form);
```

This PR addresses some security concerns that all configured authenticators rely on all configured identifiers.