### PR TITLE
Fix request and response not being modified by persistence authenticators

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -170,7 +170,7 @@ class AuthenticationService implements AuthenticationServiceInterface
             $result = $authenticator->authenticate($request, $response);
             if ($result->isValid()) {
                 if (!($authenticator instanceof StatelessInterface)) {
-                    $requestResponse = $this->setIdentity($request, $response, $result->getData());
+                    $requestResponse = $this->persistIdentity($request, $response, $result->getData());
                     $request = $requestResponse['request'];
                     $response = $requestResponse['response'];
                 }
@@ -231,7 +231,7 @@ class AuthenticationService implements AuthenticationServiceInterface
      * @param \ArrayAccess|array $identity Identity data.
      * @return array
      */
-    public function setIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity)
+    public function persistIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity)
     {
         foreach ($this->authenticators() as $authenticator) {
             if ($authenticator instanceof PersistenceInterface) {

--- a/src/AuthenticationServiceInterface.php
+++ b/src/AuthenticationServiceInterface.php
@@ -14,10 +14,11 @@
  */
 namespace Authentication;
 
+use Authentication\Authenticator\PersistenceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-interface AuthenticationServiceInterface
+interface AuthenticationServiceInterface extends PersistenceInterface
 {
 
     /**
@@ -54,25 +55,6 @@ interface AuthenticationServiceInterface
      * @return null|\Authentication\IdentityInterface
      */
     public function getIdentity();
-
-    /**
-     * Clears the identity from authenticators that store them and the request.
-     *
-     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
-     * @param \Psr\Http\Message\ResponseInterface $response The response.
-     * @return array Return an array containing the request and response objects.
-     */
-    public function clearIdentity(ServerRequestInterface $request, ResponseInterface $response);
-
-    /**
-     * Persists the given identity data in the authenticators that support persistence.
-     *
-     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
-     * @param \Psr\Http\Message\ResponseInterface $response The response.
-     * @param \ArrayAccess|array $identity Identity data.
-     * @return array Return an array containing the request and response objects.
-     */
-    public function setIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity);
 
     /**
      * Gets the successful authenticator instance if one was successful after calling authenticate

--- a/src/AuthenticationServiceInterface.php
+++ b/src/AuthenticationServiceInterface.php
@@ -14,7 +14,6 @@
  */
 namespace Authentication;
 
-use ArrayAccess;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -44,7 +43,7 @@ interface AuthenticationServiceInterface
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Message\ResponseInterface $response The response.
-     * @return \Authentication\Authenticator\ResultInterface A result object. If none of
+     * @return array An array consisting of a result object, a modified request and response. If none of
      * the adapters was a success the last failed result is returned.
      */
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response);

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -141,7 +141,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     {
         $controller = $this->getController();
 
-        $result = $this->_authentication->setIdentity(
+        $result = $this->_authentication->persistIdentity(
             $controller->request,
             $controller->response,
             $identity

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -92,9 +92,13 @@ class AuthenticationMiddleware
 
             return $response;
         }
+
+        $request = $result['request'];
         $request = $request->withAttribute('identity', $service->getIdentity());
         $request = $request->withAttribute('authentication', $service);
-        $request = $request->withAttribute('authenticationResult', $result);
+        $request = $request->withAttribute('authenticationResult', $result['result']);
+
+        $response = $result['response'];
 
         return $next($request, $response);
     }

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -198,11 +198,11 @@ class AuthenticationServiceTest extends TestCase
     }
 
     /**
-     * testSetIdentity
+     * testPersistIdentity
      *
      * @return void
      */
-    public function testSetIdentity()
+    public function testPersistIdentity()
     {
         $service = new AuthenticationService([
             'identifiers' => [
@@ -223,7 +223,7 @@ class AuthenticationServiceTest extends TestCase
         $this->assertEmpty($request->getAttribute('identity'));
 
         $data = new ArrayObject(['username' => 'florian']);
-        $result = $service->setIdentity($request, $response, $data);
+        $result = $service->persistIdentity($request, $response, $data);
 
         $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('request', $result);
@@ -242,11 +242,11 @@ class AuthenticationServiceTest extends TestCase
     }
 
     /**
-     * testSetIdentityInterface
+     * testPersistIdentityInterface
      *
      * @return void
      */
-    public function testSetIdentityInterface()
+    public function testPersistIdentityInterface()
     {
         $request = new ServerRequest();
         $response = new Response();
@@ -254,17 +254,17 @@ class AuthenticationServiceTest extends TestCase
 
         $service = new AuthenticationService();
 
-        $result = $service->setIdentity($request, $response, $identity);
+        $result = $service->persistIdentity($request, $response, $identity);
 
         $this->assertSame($identity, $result['request']->getAttribute('identity'));
     }
 
     /**
-     * testSetIdentityInterface
+     * testPersistIdentityInterface
      *
      * @return void
      */
-    public function testSetIdentityArray()
+    public function testPersistIdentityArray()
     {
         $request = new ServerRequest();
         $response = new Response();
@@ -274,7 +274,7 @@ class AuthenticationServiceTest extends TestCase
 
         $service = new AuthenticationService();
 
-        $result = $service->setIdentity($request, $response, $data);
+        $result = $service->persistIdentity($request, $response, $data);
         $this->assertInstanceOf(IdentityInterface::class, $result['request']->getAttribute('identity'));
     }
 

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -71,7 +71,10 @@ class AuthenticationServiceTest extends TestCase
         ]);
 
         $result = $service->authenticate($request, $response);
-        $this->assertTrue($result->isValid());
+        $this->assertInstanceOf(Result::class, $result['result']);
+        $this->assertInstanceOf(ServerRequestInterface::class, $result['request']);
+        $this->assertInstanceOf(ResponseInterface::class, $result['response']);
+        $this->assertTrue($result['result']->isValid());
 
         $result = $service->getAuthenticationProvider();
         $this->assertInstanceOf(FormAuthenticator::class, $result);


### PR DESCRIPTION
Modifying a request or response from `PersistenceInterface::persistIdentity()` handler had no effect.
This results in cookies not being sent to the browser using the `CookieAuthenticator`.

This fix makes sure that request and response objects are returned by `AuthenticationService::authenticate()` method and passed through in `AuthenticationMiddleware`.