### PR TITLE
Fix cookie expiration.

### DIFF
--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -134,18 +134,8 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             ];
         }
 
-        $data = $this->getConfig('cookie');
         $value = $this->_createToken($identity);
-
-        $cookie = new Cookie(
-            $data['name'],
-            $value,
-            $data['expire'],
-            $data['path'],
-            $data['domain'],
-            $data['secure'],
-            $data['httpOnly']
-        );
+        $cookie = $this->_createCookie($value);
 
         return [
             'request' => $request,
@@ -206,11 +196,34 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
      */
     public function clearIdentity(ServerRequestInterface $request, ResponseInterface $response)
     {
-        $cookie = (new Cookie($this->getConfig('cookie.name')))->withExpired();
+        $cookie = $this->_createCookie(null)->withExpired();
 
         return [
             'request' => $request,
             'response' => $response->withAddedHeader('Set-Cookie', $cookie->toHeaderValue())
         ];
+    }
+
+    /**
+     * Creates a cookie instance with configured defaults.
+     *
+     * @param mixed $value Cookie value.
+     * @return \Cake\Http\Cookie\CookieInterface
+     */
+    protected function _createCookie($value)
+    {
+        $data = $this->getConfig('cookie');
+
+        $cookie = new Cookie(
+            $data['name'],
+            $value,
+            $data['expire'],
+            $data['path'],
+            $data['domain'],
+            $data['secure'],
+            $data['httpOnly']
+        );
+
+        return $cookie;
     }
 }

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -293,6 +293,6 @@ class CookieAuthenticatorTest extends TestCase
         $this->assertInstanceOf(RequestInterface::class, $result['request']);
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
 
-        $this->assertContains('CookieAuth=; expires=Thu, 01-Jan-1970', $result['response']->getHeaderLine('Set-Cookie'));
+        $this->assertEquals('CookieAuth=; expires=Thu, 01-Jan-1970 00:00:01 UTC; path=/', $result['response']->getHeaderLine('Set-Cookie'));
     }
 }


### PR DESCRIPTION
In order to expire a cookie it needs to be send with the same config as the initially set cookie.