### PR TITLE
Implement __get() and __isset() on Identity.

### DIFF
--- a/src/Identity.php
+++ b/src/Identity.php
@@ -27,6 +27,7 @@ class Identity implements IdentityInterface
 
     /**
      * Default configuration.
+     *
      * - `fieldMap` Mapping of fields
      *
      * @var array
@@ -72,14 +73,36 @@ class Identity implements IdentityInterface
     }
 
     /**
+     * Get data from the identity using object access.
+     *
+     * @param string $field Field in the user data.
+     * @return mixed
+     */
+    public function __get($field)
+    {
+        return $this->get($field);
+    }
+
+    /**
+     * Check if the field isset() using object access.
+     *
+     * @param string $field Field in the user data.
+     * @return mixed
+     */
+    public function __isset($field)
+    {
+        return $this->get($field) !== null;
+    }
+
+    /**
      * Get data from the identity
      *
      * @param string $field Field in the user data.
      * @return mixed
      */
-    public function get($field)
+    protected function get($field)
     {
-        $map = $this->getConfig('fieldMap');
+        $map = $this->_config['fieldMap'];
         if (isset($map[$field])) {
             $field = $map[$field];
         }
@@ -100,7 +123,7 @@ class Identity implements IdentityInterface
      */
     public function offsetExists($offset)
     {
-        return isset($this->data[$offset]);
+        return $this->get($offset) !== null;
     }
 
     /**
@@ -112,11 +135,7 @@ class Identity implements IdentityInterface
      */
     public function offsetGet($offset)
     {
-        if (isset($this->data[$offset])) {
-            return $this->data[$offset];
-        }
-
-        return null;
+        return $this->get($offset);
     }
 
     /**
@@ -129,6 +148,10 @@ class Identity implements IdentityInterface
      */
     public function offsetSet($offset, $value)
     {
+        $map = $this->_config['fieldMap'];
+        if (isset($map[$offset])) {
+            $offset = $map[$offset];
+        }
         return $this->data[$offset] = $value;
     }
 
@@ -141,6 +164,10 @@ class Identity implements IdentityInterface
      */
     public function offsetUnset($offset)
     {
+        $map = $this->_config['fieldMap'];
+        if (isset($map[$field])) {
+            $offset = $map[$offset];
+        }
         unset($this->data[$offset]);
     }
 

--- a/src/Identity.php
+++ b/src/Identity.php
@@ -152,6 +152,7 @@ class Identity implements IdentityInterface
         if (isset($map[$offset])) {
             $offset = $map[$offset];
         }
+
         return $this->data[$offset] = $value;
     }
 
@@ -165,7 +166,7 @@ class Identity implements IdentityInterface
     public function offsetUnset($offset)
     {
         $map = $this->_config['fieldMap'];
-        if (isset($map[$field])) {
+        if (isset($map[$offset])) {
             $offset = $map[$offset];
         }
         unset($this->data[$offset]);

--- a/src/Identity.php
+++ b/src/Identity.php
@@ -15,6 +15,7 @@
 namespace Authentication;
 
 use ArrayAccess;
+use BadMethodCallException;
 use Cake\Core\InstanceConfigTrait;
 use InvalidArgumentException;
 
@@ -144,16 +145,12 @@ class Identity implements IdentityInterface
      * @link http://php.net/manual/en/arrayaccess.offsetset.php
      * @param mixed $offset The offset to assign the value to.
      * @param mixed $value Value
+     * @throws \BadMethodCallException
      * @return mixed
      */
     public function offsetSet($offset, $value)
     {
-        $map = $this->_config['fieldMap'];
-        if (isset($map[$offset])) {
-            $offset = $map[$offset];
-        }
-
-        return $this->data[$offset] = $value;
+        throw new BadMethodCallException('Identity does not allow wrapped data to be mutated.');
     }
 
     /**
@@ -161,15 +158,12 @@ class Identity implements IdentityInterface
      *
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset Offset
+     * @throws \BadMethodCallException
      * @return void
      */
     public function offsetUnset($offset)
     {
-        $map = $this->_config['fieldMap'];
-        if (isset($map[$offset])) {
-            $offset = $map[$offset];
-        }
-        unset($this->data[$offset]);
+        throw new BadMethodCallException('Identity does not allow wrapped data to be mutated.');
     }
 
     /**

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -111,7 +111,7 @@ class AuthenticationComponentTest extends TestCase
 
         $result = $component->getIdentity();
         $this->assertInstanceOf(IdentityInterface::class, $result);
-        $this->assertEquals('florian', $result->get('username'));
+        $this->assertEquals('florian', $result->username);
     }
 
     /**
@@ -203,7 +203,7 @@ class AuthenticationComponentTest extends TestCase
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
-        $this->assertEquals('florian', $controller->request->getAttribute('identity')->get('username'));
+        $this->assertEquals('florian', $controller->request->getAttribute('identity')->username);
         $component->logout();
         $this->assertNull($controller->request->getAttribute('identity'));
         $this->assertInstanceOf(Event::class, $result);

--- a/tests/TestCase/IdentityTest.php
+++ b/tests/TestCase/IdentityTest.php
@@ -16,6 +16,7 @@ namespace Authentication\Test\TestCase;
 
 use ArrayObject;
 use Authentication\Identity;
+use BadMethodCallException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 
@@ -72,14 +73,38 @@ class IdentityTest extends TestCase
         $this->assertSame('florian', $identity['username'], 'renamed field responsds to offsetget');
         $this->assertSame('florian', $identity->username, 'renamed field responds to__get');
         $this->assertNull($identity->missing);
+    }
+
+    /**
+     * Identities disallow data being unset.
+     *
+     * @return void
+     */
+    public function testOffsetUnsetError()
+    {
+        $this->setExpectedException(BadMethodCallException::class);
+        $data = [
+            'id' => 1,
+        ];
+        $identity = new Identity($data);
+        unset($identity['id']);
 
         $identity['username'] = 'mark';
-        $this->assertSame('mark', $identity->username);
-        $this->assertSame('mark', $identity->first_name);
+    }
 
-        $identity->username = 'nope';
-        $this->assertSame('mark', $identity->first_name);
-        $this->assertSame('nope', $identity->username, 'adding public properties works');
+    /**
+     * Identities disallow data being set.
+     *
+     * @return void
+     */
+    public function testOffsetSetError()
+    {
+        $this->setExpectedException(BadMethodCallException::class);
+        $data = [
+            'id' => 1,
+        ];
+        $identity = new Identity($data);
+        $identity['username'] = 'mark';
     }
 
     /**

--- a/tests/TestCase/IdentityTest.php
+++ b/tests/TestCase/IdentityTest.php
@@ -12,7 +12,7 @@
  * @since         1.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Authentication\Test\TestCase\Authenticator;
+namespace Authentication\Test\TestCase;
 
 use ArrayObject;
 use Authentication\Identity;
@@ -38,8 +38,7 @@ class IdentityTest extends TestCase
         $result = $identity->getIdentifier();
         $this->assertEquals(1, $result);
 
-        $result = $identity->get('username');
-        $this->assertEquals('florian', $result);
+        $this->assertEquals('florian', $identity->username);
     }
 
     /**
@@ -62,11 +61,25 @@ class IdentityTest extends TestCase
             ]
         ]);
 
-        $result = $identity->get('username');
-        $this->assertEquals('florian', $result);
+        $this->assertTrue(isset($identity['username']), 'Renamed field responds to isset');
+        $this->assertTrue(isset($identity['first_name']), 'old alias responds to isset.');
+        $this->assertFalse(isset($identity['missing']));
 
-        $result = $identity->get('email');
-        $this->assertEquals('info@cakephp.org', $result);
+        $this->assertTrue(isset($identity->username), 'Renamed field responds to isset');
+        $this->assertTrue(isset($identity->first_name), 'old alias responds to isset.');
+        $this->assertFalse(isset($identity->missing));
+
+        $this->assertSame('florian', $identity['username'], 'renamed field responsds to offsetget');
+        $this->assertSame('florian', $identity->username, 'renamed field responds to__get');
+        $this->assertNull($identity->missing);
+
+        $identity['username'] = 'mark';
+        $this->assertSame('mark', $identity->username);
+        $this->assertSame('mark', $identity->first_name);
+
+        $identity->username = 'nope';
+        $this->assertSame('mark', $identity->first_name);
+        $this->assertSame('nope', $identity->username, 'adding public properties works');
     }
 
     /**

--- a/tests/TestCase/IdentityTest.php
+++ b/tests/TestCase/IdentityTest.php
@@ -19,6 +19,7 @@ use Authentication\Identity;
 use BadMethodCallException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 class IdentityTest extends TestCase
 {
@@ -82,7 +83,7 @@ class IdentityTest extends TestCase
      */
     public function testOffsetUnsetError()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $data = [
             'id' => 1,
         ];
@@ -99,7 +100,7 @@ class IdentityTest extends TestCase
      */
     public function testOffsetSetError()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $data = [
             'id' => 1,
         ];
@@ -117,12 +118,10 @@ class IdentityTest extends TestCase
         $this->assertEquals($data['username'], $identity['username']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedException Array data must be an `array` or implement `ArrayAccess` interface, `stdClass` given.
-     */
     public function testBuildInvalidArgument()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('data must be an `array` or implement `ArrayAccess` interface, `stdClass` given.');
         new Identity(new \stdClass);
     }
 


### PR DESCRIPTION
This makes reading data simpler. I've also used field mappings consistently as they were only applied in some situations before.

I've made Identity::get() protected as I don't think we need 3 ways to access properties.