### PR TITLE
Remove weak type comparisons

### DIFF
--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -49,13 +49,13 @@ abstract class AbstractCollection extends ObjectRegistry implements IteratorAggr
     }
 
     /**
-     * Returns true if a collection is empty.
+     * Returns true if the map of identifier objects is empty.
      *
      * @return bool
      */
     public function isEmpty()
     {
-        return empty($this->_loaded);
+        return $this->_loaded === [];
     }
 
     /**

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -101,10 +101,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
 
         list($username, $tokenHash) = $token;
 
-        $credentials = [
-            'username' => $username
-        ];
-        $identity = $this->_identifier->identify($credentials);
+        $identity = $this->_identifier->identify(['username' => $username]);
 
         if (empty($identity)) {
             return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
@@ -127,7 +124,9 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
         $field = $this->getConfig('rememberMeField');
         $bodyData = $request->getParsedBody();
 
-        if (!$this->_checkUrl($request) || !is_array($bodyData) || empty($bodyData[$field])) {
+        if (!$this->_checkUrl($request) || !is_array($bodyData) || !array_key_exists($field, $bodyData)
+            || in_array($bodyData[$field], [false, null, ''], true)
+        ) {
             return [
                 'request' => $request,
                 'response' => $response

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -73,7 +73,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
      */
     protected function _checkCakeVersion()
     {
-        if (!class_exists('Cake\Http\Cookie\Cookie')) {
+        if (!class_exists(Cookie::class)) {
             throw new RuntimeException('Install CakePHP version >=3.5.0 to use the `CookieAuthenticator`.');
         }
     }

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -85,7 +85,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
     {
         $cookies = $request->getCookieParams();
         $cookieName = $this->getConfig('cookie.name');
-        if (!isset($cookies[$cookieName])) {
+        if (!array_key_exists($cookieName, $cookies)) {
             return new Result(null, Result::FAILURE_CREDENTIALS_MISSING, [
                 'Login credentials not found'
             ]);

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -54,7 +54,7 @@ class FormAuthenticator extends AbstractAuthenticator
      */
     protected function _getData(ServerRequestInterface $request)
     {
-        $fields = $this->_config['fields'];
+        $fields = $this->getConfig('fields');
         $body = $request->getParsedBody();
 
         $data = [];

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -115,12 +115,12 @@ class FormAuthenticator extends AbstractAuthenticator
             ]);
         }
 
-        $user = $this->_identifier->identify($data);
+        $identity = $this->_identifier->identify($data);
 
-        if (empty($user)) {
+        if (empty($identity)) {
             return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
         }
 
-        return new Result($user, Result::SUCCESS);
+        return new Result($identity, Result::SUCCESS);
     }
 }

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -91,7 +91,7 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
     protected function loginHeaders(ServerRequestInterface $request)
     {
         $server = $request->getServerParams();
-        $realm = $this->getConfig('realm') ?: $server['SERVER_NAME'];
+        $realm = $this->getConfig('realm') === null ? $server['SERVER_NAME'] : $this->getConfig('realm');
 
         return ['WWW-Authenticate' => sprintf('Basic realm="%s"', $realm)];
     }

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -53,7 +53,7 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
     public function getUser(ServerRequestInterface $request)
     {
         $server = $request->getServerParams();
-        if (!isset($server['PHP_AUTH_USER']) || !isset($server['PHP_AUTH_PW'])) {
+        if (!array_key_exists('PHP_AUTH_USER', $server) || !array_key_exists('PHP_AUTH_PW', $server)) {
             return null;
         }
 

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -35,13 +35,13 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
      */
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response)
     {
-        $user = $this->getUser($request);
+        $identity = $this->getUser($request);
 
-        if (empty($user)) {
+        if (empty($identity)) {
             return new Result(null, Result::FAILURE_CREDENTIALS_MISSING);
         }
 
-        return new Result($user, Result::SUCCESS);
+        return new Result($identity, Result::SUCCESS);
     }
 
     /**
@@ -66,7 +66,7 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
 
         return $this->_identifier->identify([
             IdentifierInterface::CREDENTIAL_USERNAME => $username,
-            IdentifierInterface::CREDENTIAL_PASSWORD => $password
+            IdentifierInterface::CREDENTIAL_PASSWORD => $password,
         ]);
     }
 

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -52,29 +52,30 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     {
         $sessionKey = $this->getConfig('sessionKey');
         $session = $request->getAttribute('session');
-        $user = $session->read($sessionKey);
+        $identity = $session->read($sessionKey);
 
-        if (empty($user)) {
+        if (empty($identity)) {
             return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
         }
 
         if ($this->getConfig('identify') === true) {
             $credentials = [];
             foreach ($this->getConfig('fields') as $key => $field) {
-                $credentials[$key] = $user[$field];
+                $credentials[$key] = $identity[$field];
             }
-            $user = $this->_identifier->identify($credentials);
 
-            if (empty($user)) {
+            $identity = $this->_identifier->identify($credentials);
+
+            if (empty($identity)) {
                 return new Result(null, Result::FAILURE_CREDENTIALS_INVALID);
             }
         }
 
-        if (!($user instanceof ArrayAccess)) {
-            $user = new ArrayObject($user);
+        if (!($identity instanceof ArrayAccess)) {
+            $identity = new ArrayObject($identity);
         }
 
-        return new Result($user, Result::SUCCESS);
+        return new Result($identity, Result::SUCCESS);
     }
 
     /**

--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -98,11 +98,11 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
     {
         $queryParams = $request->getQueryParams();
 
-        if (isset($queryParams[$queryParam])) {
-            return $queryParams[$queryParam];
+        if (!array_key_exists($queryParam, $queryParams)) {
+            return null;
         }
 
-        return null;
+        return $queryParams[$queryParam];
     }
 
     /**

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -76,7 +76,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     {
         $provider = $this->_authentication->getAuthenticationProvider();
 
-        if (empty($provider) ||
+        if ($provider === null ||
             $provider instanceof PersistenceInterface ||
             $provider instanceof StatelessInterface
         ) {

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -29,6 +29,13 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
     protected $_errors = [];
 
     /**
+     * Map of loaded objects.
+     *
+     * @var object[]
+     */
+    protected $_loaded = [];
+
+    /**
      * Identifies an user or service by the passed credentials
      *
      * @param array $credentials Authentication credentials

--- a/src/Identifier/Ldap/ExtensionAdapter.php
+++ b/src/Identifier/Ldap/ExtensionAdapter.php
@@ -32,9 +32,9 @@ class ExtensionAdapter implements AdapterInterface
     /**
      * LDAP Object
      *
-     * @var object|null
+     * @var object|false|null
      */
-    protected $_connection;
+    protected $_connection = null;
 
     /**
      * Constructor
@@ -76,7 +76,7 @@ class ExtensionAdapter implements AdapterInterface
      */
     public function getConnection()
     {
-        if (empty($this->_connection)) {
+        if ($this->_connection === false || $this->_connection === null) {
             throw new RuntimeException('You are not connected to a LDAP server.');
         }
 

--- a/src/Identifier/LdapIdentifier.php
+++ b/src/Identifier/LdapIdentifier.php
@@ -92,17 +92,17 @@ class LdapIdentifier extends AbstractIdentifier
      */
     protected function _checkLdapConfig()
     {
-        if (!isset($this->_config['bindDN'])) {
-            throw new RuntimeException('Config `bindDN` is not set.');
+        if ($this->getConfig('bindDN') === null) {
+            throw new RuntimeException('Config key `bindDN` is not set.');
         }
-        if (!is_callable($this->_config['bindDN'])) {
+        if (!is_callable($this->getConfig('bindDN'))) {
             throw new InvalidArgumentException(sprintf(
-                'The `bindDN` config is not a callable. Got `%s` instead.',
-                gettype($this->_config['bindDN'])
+                'The value of `bindDN` config key is not a callable. Got `%s` instead.',
+                gettype($this->getConfig('bindDN'))
             ));
         }
-        if (!isset($this->_config['host'])) {
-            throw new RuntimeException('Config `host` is not set.');
+        if ($this->getConfig('host') === null || trim($this->getConfig('host') === '')) {
+            throw new RuntimeException('Config key `host` is not set.');
         }
     }
 
@@ -114,7 +114,7 @@ class LdapIdentifier extends AbstractIdentifier
      */
     protected function _buildLdapObject()
     {
-        $ldap = $this->_config['ldap'];
+        $ldap = $this->getConfig('ldap');
 
         if (is_string($ldap)) {
             $class = App::className($ldap, 'Identifier/Ldap');
@@ -137,8 +137,13 @@ class LdapIdentifier extends AbstractIdentifier
         $this->_connectLdap();
         $fields = $this->getConfig('fields');
 
-        if (isset($data[$fields[self::CREDENTIAL_USERNAME]]) && isset($data[$fields[self::CREDENTIAL_PASSWORD]])) {
-            return $this->_bindUser($data[$fields[self::CREDENTIAL_USERNAME]], $data[$fields[self::CREDENTIAL_PASSWORD]]);
+        if (array_key_exists($fields[self::CREDENTIAL_USERNAME], $data)
+            && array_key_exists($fields[self::CREDENTIAL_PASSWORD], $data)
+        ) {
+            return $this->_bindUser(
+                $data[$fields[self::CREDENTIAL_USERNAME]],
+                $data[$fields[self::CREDENTIAL_PASSWORD]]
+            );
         }
 
         return null;

--- a/src/Identifier/Resolver/OrmResolver.php
+++ b/src/Identifier/Resolver/OrmResolver.php
@@ -53,10 +53,10 @@ class OrmResolver implements ResolverInterface
      */
     public function find(array $conditions, $type = self::TYPE_AND)
     {
-        $table = $this->tableLocator()->get($this->_config['userModel']);
+        $table = $this->tableLocator()->get($this->getConfig('userModel'));
 
         $query = $table->query();
-        $finders = (array)$this->_config['finder'];
+        $finders = (array)$this->getConfig('finder');
         foreach ($finders as $finder => $options) {
             if (is_string($options)) {
                 $query->find($options);

--- a/src/Identifier/Resolver/ResolverAwareTrait.php
+++ b/src/Identifier/Resolver/ResolverAwareTrait.php
@@ -77,7 +77,7 @@ trait ResolverAwareTrait
             ];
         }
 
-        if (!isset($config['className'])) {
+        if (!array_key_exists('className', $config)) {
             $message = 'Option `className` is not present.';
             throw new InvalidArgumentException($message);
         }

--- a/src/Identity.php
+++ b/src/Identity.php
@@ -80,7 +80,7 @@ class Identity implements IdentityInterface
     public function get($field)
     {
         $map = $this->getConfig('fieldMap');
-        if (isset($map[$field])) {
+        if (array_key_exists($field, $map)) {
             $field = $map[$field];
         }
 

--- a/src/PasswordHasher/DefaultPasswordHasher.php
+++ b/src/PasswordHasher/DefaultPasswordHasher.php
@@ -46,8 +46,8 @@ class DefaultPasswordHasher extends AbstractPasswordHasher
     {
         return password_hash(
             $password,
-            $this->_config['hashType'],
-            $this->_config['hashOptions']
+            $this->getConfig('hashType'),
+            $this->getConfig('hashOptions')
         );
     }
 
@@ -72,6 +72,6 @@ class DefaultPasswordHasher extends AbstractPasswordHasher
      */
     public function needsRehash($password)
     {
-        return password_needs_rehash($password, $this->_config['hashType'], $this->_config['hashOptions']);
+        return password_needs_rehash($password, $this->getConfig('hashType'), $this->getConfig('hashOptions'));
     }
 }

--- a/src/PasswordHasher/FallbackPasswordHasher.php
+++ b/src/PasswordHasher/FallbackPasswordHasher.php
@@ -47,8 +47,8 @@ class FallbackPasswordHasher extends AbstractPasswordHasher
     public function __construct(array $config = [])
     {
         parent::__construct($config);
-        foreach ($this->_config['hashers'] as $key => $hasher) {
-            if (is_array($hasher) && !isset($hasher['className'])) {
+        foreach ($this->getConfig('hashers') as $key => $hasher) {
+            if (is_array($hasher) && !array_key_exists('className', $hasher)) {
                 $hasher['className'] = $key;
             }
             $this->_hashers[] = PasswordHasherFactory::build($hasher);

--- a/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/src/PasswordHasher/LegacyPasswordHasher.php
@@ -57,7 +57,7 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
      */
     public function hash($password)
     {
-        return Security::hash($password, $this->_config['hashType'], true);
+        return Security::hash($password, $this->getConfig('hashType'), true);
     }
 
     /**

--- a/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/src/PasswordHasher/LegacyPasswordHasher.php
@@ -44,7 +44,7 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
         if (Configure::read('debug')) {
             Debugger::checkSecurityKeys();
         }
-        if (!class_exists('Cake\Utility\Security')) {
+        if (!class_exists(Security::class)) {
             throw new RuntimeException('You must install the cakephp/utility dependency to use this password hasher');
         };
     }

--- a/src/UrlChecker/DefaultUrlChecker.php
+++ b/src/UrlChecker/DefaultUrlChecker.php
@@ -84,7 +84,7 @@ class DefaultUrlChecker implements UrlCheckerInterface
      */
     protected function _getChecker(array $options = [])
     {
-        if (isset($options['useRegex']) && $options['useRegex']) {
+        if (array_key_exists('useRegex', $options) && $options['useRegex'] === true) {
             return 'preg_match';
         }
 

--- a/src/UrlChecker/DefaultUrlChecker.php
+++ b/src/UrlChecker/DefaultUrlChecker.php
@@ -44,7 +44,7 @@ class DefaultUrlChecker implements UrlCheckerInterface
 
         $urls = (array)$urls;
 
-        if (empty($urls)) {
+        if ($urls === []) {
             return true;
         }
 

--- a/src/UrlChecker/UrlCheckerInterface.php
+++ b/src/UrlChecker/UrlCheckerInterface.php
@@ -25,9 +25,9 @@ interface UrlCheckerInterface
      * Checks the requests if it is the configured login action
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request Server Request
-     * @param string|array $loginUrls Login URL string or array of URLs
+     * @param string|array $urls Login URL string or array of URLs
      * @param array $options Array of options
      * @return bool
      */
-    public function check(ServerRequestInterface $request, $loginUrls, array $options = []);
+    public function check(ServerRequestInterface $request, $urls, array $options = []);
 }

--- a/src/UrlChecker/UrlCheckerTrait.php
+++ b/src/UrlChecker/UrlCheckerTrait.php
@@ -53,7 +53,7 @@ trait UrlCheckerTrait
                 'className' => $options
             ];
         }
-        if (!isset($options['className'])) {
+        if (!array_key_exists('className', $options)) {
             $options['className'] = DefaultUrlChecker::class;
         }
 

--- a/tests/TestCase/Identifier/LdapIdentifierTest.php
+++ b/tests/TestCase/Identifier/LdapIdentifierTest.php
@@ -137,7 +137,7 @@ class LdapIdentifierTest extends TestCase
      *
      * @return void
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Config `bindDN` is not set.
+     * @expectedExceptionMessage Config key `bindDN` is not set.
      */
     public function testMissingBindDN()
     {
@@ -151,7 +151,7 @@ class LdapIdentifierTest extends TestCase
      *
      * @return void
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The `bindDN` config is not a callable. Got `string` instead.
+     * @expectedExceptionMessage The value of `bindDN` config key is not a callable. Got `string` instead.
      */
     public function testUncallableDN()
     {
@@ -166,7 +166,7 @@ class LdapIdentifierTest extends TestCase
      *
      * @return void
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Config `host` is not set.
+     * @expectedExceptionMessage Config key `host` is not set.
      */
     public function testMissingHost()
     {


### PR DESCRIPTION
* Remove most of the `empty()` uses aside when comparing against `null|array|ArrayAccess`
* unified uses of `$user` vs `$identity` to latter
* replaced some `isset()` comparisons with `array_key_exists()`
* replaced `$this->_config[$something]` calls with $this->getConfig($something) calls.
* fixed ldap_connect integration which actually returns false not null.
* made some class_exists() checks less stringy.

Fixes https://github.com/cakephp/authentication/issues/174