### PR TITLE
more strict on nulls, ::class over string-class, early returns

### DIFF
--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -73,7 +73,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
      */
     protected function _checkCakeVersion()
     {
-        if (!class_exists('Cake\Http\Cookie\Cookie')) {
+        if (!class_exists(Cookie::class)) {
             throw new RuntimeException('Install CakePHP version >=3.5.0 to use the `CookieAuthenticator`.');
         }
     }
@@ -101,10 +101,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
 
         list($username, $tokenHash) = $token;
 
-        $credentials = [
-            'username' => $username
-        ];
-        $identity = $this->_identifier->identify($credentials);
+        $identity = $this->_identifier->identify(compact('username'));
 
         if (empty($identity)) {
             return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -66,7 +66,7 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
 
         return $this->_identifier->identify([
             IdentifierInterface::CREDENTIAL_USERNAME => $username,
-            IdentifierInterface::CREDENTIAL_PASSWORD => $password
+            IdentifierInterface::CREDENTIAL_PASSWORD => $password,
         ]);
     }
 

--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -78,7 +78,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response)
     {
         $digest = $this->_getDigest($request);
-        if (empty($digest)) {
+        if ($digest === null) {
             return new Result(null, Result::FAILURE_CREDENTIALS_MISSING);
         }
 
@@ -114,7 +114,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
      * Gets the digest headers from the request/environment.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
-     * @return array Array of digest information.
+     * @return array|null Array of digest information.
      */
     protected function _getDigest(ServerRequestInterface $request)
     {
@@ -127,7 +127,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
             }
         }
         if (empty($digest)) {
-            return [];
+            return null;
         }
 
         return $this->parseAuthData($digest);
@@ -209,7 +209,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
         ];
 
         $digest = $this->_getDigest($request);
-        if ($digest && isset($digest['nonce']) && !$this->validNonce($digest['nonce'])) {
+        if ($digest !== null && isset($digest['nonce']) && !$this->validNonce($digest['nonce'])) {
             $options['stale'] = true;
         }
 

--- a/src/Authenticator/JwtAuthenticator.php
+++ b/src/Authenticator/JwtAuthenticator.php
@@ -16,6 +16,7 @@ namespace Authentication\Authenticator;
 
 use ArrayObject;
 use Authentication\Identifier\IdentifierInterface;
+use Cake\Utility\Security;
 use Exception;
 use Firebase\JWT\JWT;
 use Psr\Http\Message\ResponseInterface;

--- a/src/Authenticator/JwtAuthenticator.php
+++ b/src/Authenticator/JwtAuthenticator.php
@@ -53,7 +53,7 @@ class JwtAuthenticator extends TokenAuthenticator
         parent::__construct($identifier, $config);
 
         if (empty($this->_config['secretKey'])) {
-            if (!class_exists('Cake\Utility\Security')) {
+            if (!class_exists(Security::class)) {
                 throw new RuntimeException('You must set the `secretKey` config key for JWT authentication.');
             }
             $this->setConfig('secretKey', \Cake\Utility\Security::salt());
@@ -126,11 +126,13 @@ class JwtAuthenticator extends TokenAuthenticator
         $payload = null;
         $token = $this->getToken($request);
 
-        if ($token) {
+        if ($token !== null) {
             $payload = $this->decodeToken($token);
         }
 
-        return $this->payload = $payload;
+        $this->payload = $payload;
+
+        return $this->payload;
     }
 
     /**

--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -44,12 +44,12 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
     protected function getToken(ServerRequestInterface $request)
     {
         $token = $this->getTokenFromHeader($request, $this->getConfig('header'));
-        if (empty($token)) {
+        if ($token === null) {
             $token = $this->getTokenFromQuery($request, $this->getConfig('queryParam'));
         }
 
         $prefix = $this->getConfig('tokenPrefix');
-        if (is_string($token) && !empty($prefix)) {
+        if ($prefix !== null && is_string($token)) {
             return $this->stripTokenPrefix($token, $prefix);
         }
 
@@ -98,11 +98,11 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
     {
         $queryParams = $request->getQueryParams();
 
-        if (isset($queryParams[$queryParam])) {
-            return $queryParams[$queryParam];
+        if (!array_key_exists($queryParam, $queryParams)) {
+            return null;
         }
 
-        return null;
+        return $queryParams[$queryParam];
     }
 
     /**
@@ -117,7 +117,7 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
     public function authenticate(ServerRequestInterface $request, ResponseInterface $response)
     {
         $token = $this->getToken($request);
-        if (empty($token)) {
+        if ($token === null) {
             return new Result(null, Result::FAILURE_CREDENTIALS_MISSING);
         }
 

--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -98,7 +98,7 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
     {
         $queryParams = $request->getQueryParams();
 
-        if (!array_key_exists($queryParam, $queryParams)) {
+        if (empty($queryParams[$queryParam])) {
             return null;
         }
 

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -76,7 +76,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     {
         $provider = $this->_authentication->getAuthenticationProvider();
 
-        if (empty($provider) ||
+        if ($provider === null ||
             $provider instanceof PersistenceInterface ||
             $provider instanceof StatelessInterface
         ) {

--- a/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/src/PasswordHasher/LegacyPasswordHasher.php
@@ -44,7 +44,7 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
         if (Configure::read('debug')) {
             Debugger::checkSecurityKeys();
         }
-        if (!class_exists('Cake\Utility\Security')) {
+        if (!class_exists(Security::class)) {
             throw new RuntimeException('You must install the cakephp/utility dependency to use this password hasher');
         };
     }

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -20,6 +20,7 @@ use Authentication\Identifier\IdentifierCollection;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
+use Cake\Http\Cookie\Cookie;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -41,7 +42,7 @@ class CookieAuthenticatorTest extends TestCase
      */
     public function setUp()
     {
-        $this->skipIf(!class_exists('\Cake\Http\Cookie\Cookie'));
+        $this->skipIf(!class_exists(Cookie::class));
 
         parent::setUp();
     }

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -17,10 +17,10 @@ use ArrayObject;
 use Authentication\Authenticator\CookieAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
+use Cake\Http\Cookie\Cookie;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
-use Cake\Http\Cookie\Cookie;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 


### PR DESCRIPTION
I hope I got the (hopefully) better parts of https://github.com/cakephp/authentication/pull/175 isolated.
I still have a very bad feeling about `isset()` and `empty()` TBH and I feel things my gut feeling is that things might bite back in 7.1/7.2.