### PR TITLE
Unauthenticated actions

### DIFF
--- a/docs/Migration-from-the-AuthComponent.md
+++ b/docs/Migration-from-the-AuthComponent.md
@@ -121,7 +121,7 @@ specific actions 'public' and not require a valid identity to be present:
 
 ```php
 // In your controller's beforeFilter method.
-$this->Authentication->allowUnauthorized(['view']);
+$this->Authentication->allowUnauthenticated(['view']);
 ```
 
-Each call to `allowUnauthorized()` will overwrite the current action list.
+Each call to `allowUnauthenticated()` will overwrite the current action list.

--- a/docs/Migration-from-the-AuthComponent.md
+++ b/docs/Migration-from-the-AuthComponent.md
@@ -113,4 +113,15 @@ $this->Authentication->setIdentity($user);
 While there is a bit more code than before, you have more flexibility in how
 your authentication is handled.
 
+## Migrating allow/deny logic
 
+Like `AuthComponent` the `AuthenticationComponent` makes it easy to make
+specific actions 'public' and not require a valid identity to be present:
+
+
+```php
+// In your controller's beforeFilter method.
+$this->Authentication->allowUnauthorized(['view']);
+```
+
+Each call to `allowUnauthorized()` will overwrite the current action list.

--- a/docs/Quick-start-and-introduction.md
+++ b/docs/Quick-start-and-introduction.md
@@ -106,7 +106,16 @@ $this->loadComponent('Authentication.Authentication', [
 ]);
 ```
 
-## Accessing the user / identity data
+Once loaded, the `AuthenticationComponent` will require that all actions have an
+authenticated user present, but perform no other access control checks. You can
+disable this check for specific actions using `allowUnauthorized()`:
+
+```php
+// In your controller's beforeFilter method.
+$this->Authentication->allowUnauthorized(['view']);
+```
+
+### Accessing the user / identity data
 
 You can get the authenticated identity data using the authentication component:
 
@@ -120,7 +129,7 @@ You can also get the identity directly from the request instance:
 $user = $request->getAttribute('identity');
 ```
 
-## Checking the login status
+### Checking the login status
 
 You can check if the authentication process was successful by accessing the result
 object:
@@ -150,7 +159,7 @@ The result sets objects status returned from `getStatus()` will match one of the
 
 The error array returned by `getErrors()` contains *additional* information coming from the specific system against which the authentication attempt was made. For example LDAP or OAuth would put errors specific to their implementation in here for easier logging and debugging the cause. But most of the included authenticators don't put anything in here.
 
-## Clearing the identity / logging the user out
+### Clearing the identity / logging the user out
 
 To log an identity out just do:
 

--- a/docs/Quick-start-and-introduction.md
+++ b/docs/Quick-start-and-introduction.md
@@ -108,11 +108,11 @@ $this->loadComponent('Authentication.Authentication', [
 
 Once loaded, the `AuthenticationComponent` will require that all actions have an
 authenticated user present, but perform no other access control checks. You can
-disable this check for specific actions using `allowUnauthorized()`:
+disable this check for specific actions using `allowUnauthenticated()`:
 
 ```php
 // In your controller's beforeFilter method.
-$this->Authentication->allowUnauthorized(['view']);
+$this->Authentication->allowUnauthenticated(['view']);
 ```
 
 ### Accessing the user / identity data

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -151,6 +151,16 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     }
 
     /**
+     * Get the current list of actions that don't require authentication.
+     *
+     * @return array
+     */
+    public function getUnauthenticatedActions()
+    {
+        return $this->unauthenticatedActions;
+    }
+
+    /**
      * Gets the result of the last authenticate() call.
      *
      * @return \Authentication\Authenticator\ResultInterface|null Authentication result interface

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -151,6 +151,20 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     }
 
     /**
+     * Add to the list of actions that don't require an authentication identity to be present.
+     *
+     * @param array $actions The action or actions to append.
+     * @return $this
+     */
+    public function addUnauthenticatedActions(array $actions)
+    {
+        $this->unauthenticatedActions = array_merge($this->unauthenticatedActions, $actions);
+        $this->unauthenticatedActions = array_values(array_unique($this->unauthenticatedActions));
+
+        return $this;
+    }
+
+    /**
      * Get the current list of actions that don't require authentication.
      *
      * @return array

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -18,6 +18,7 @@ use ArrayAccess;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\Authenticator\PersistenceInterface;
 use Authentication\Authenticator\StatelessInterface;
+use Authentication\Authenticator\UnauthorizedException;
 use Cake\Controller\Component;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
@@ -26,16 +27,35 @@ use Cake\Utility\Hash;
 use Exception;
 use RuntimeException;
 
+/**
+ * Controller Component for interacting with Authentication.
+ *
+ */
 class AuthenticationComponent extends Component implements EventDispatcherInterface
 {
     use EventDispatcherTrait;
 
     /**
-     * {@inheritDoc}
+     * Configuration options
+     *
+     * - `logoutRedirect` - The route/URL to direct users to after logout()
+     * - `requireIdentity` - By default AuthenticationComponent will require an
+     *   identity to be present whenever it is active. You can set the option to
+     *   false to disable that behavior. See allowUnauthenticated() as well.
+     *
+     * @var array
      */
     protected $_defaultConfig = [
-        'logoutRedirect' => false
+        'logoutRedirect' => false,
+        'requireIdentity' => true,
     ];
+
+    /**
+     * List of actions that don't require authentication.
+     *
+     * @var array
+     */
+    protected $unauthenticatedActions = [];
 
     /**
      * Authentication service instance.
@@ -87,6 +107,47 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
             'identity' => $this->getIdentity(),
             'service' => $this->_authentication
         ], $this->getController());
+    }
+
+    /**
+     * Start up event handler
+     *
+     * If `requireIdentity` is true, the action will be compared to the
+     * allowed actions.
+     *
+     * @return void
+     */
+    public function startup()
+    {
+        if (!$this->getConfig('requireIdentity')) {
+            return;
+        }
+        $request = $this->getController()->request;
+        $action = $request->getParam('action');
+        if (in_array($action, $this->unauthenticatedActions)) {
+            return;
+        }
+
+        $identity = $request->getAttribute('identity');
+        if (!$identity) {
+            throw new UnauthorizedException([]);
+        }
+    }
+
+    /**
+     * Set the list of actions that don't require an authentication identity to be present.
+     *
+     * Actions not in this list will require an identity to be present. Any
+     * valid identity will pass this constraint.
+     *
+     * @param array $actions The action list.
+     * @return $this
+     */
+    public function allowUnauthenticated(array $actions)
+    {
+        $this->unauthenticatedActions = $actions;
+
+        return $this;
     }
 
     /**
@@ -157,7 +218,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      *
      * Triggers the `Authentication.logout` event.
      *
-     * @return string|null
+     * @return string|null Returns null or `logoutRedirect`.
      */
     public function logout()
     {

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -266,6 +266,7 @@ class AuthenticationComponentTest extends TestCase
         $controller->loadComponent('Authentication.Authentication');
 
         $controller->Authentication->allowUnauthenticated(['view']);
+        $this->assertSame(['view'], $controller->Authentication->getUnauthenticatedActions());
         $controller->startupProcess();
         $this->assertTrue(true, 'No exception should be raised');
     }

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -30,6 +30,9 @@ use Cake\Network\Response;
 use Cake\ORM\Entity;
 use TestApp\Authentication\InvalidAuthenticationService;
 
+/**
+ * Authentication component test.
+ */
 class AuthenticationComponentTest extends TestCase
 {
 
@@ -89,8 +92,8 @@ class AuthenticationComponentTest extends TestCase
      */
     public function testInitializeInvalidServiceObject()
     {
-        $this->request = $this->request->withAttribute('authentication', new InvalidAuthenticationService());
-        $controller = new Controller($this->request, $this->response);
+        $request = $this->request->withAttribute('authentication', new InvalidAuthenticationService());
+        $controller = new Controller($request, $this->response);
         $registry = new ComponentRegistry($controller);
         new AuthenticationComponent($registry);
     }
@@ -102,10 +105,11 @@ class AuthenticationComponentTest extends TestCase
      */
     public function testGetIdentity()
     {
-        $this->request = $this->request->withAttribute('identity', $this->identity);
-        $this->request = $this->request->withAttribute('authentication', $this->service);
+        $request = $this->request
+            ->withAttribute('identity', $this->identity)
+            ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($this->request, $this->response);
+        $controller = new Controller($request, $this->response);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -121,9 +125,9 @@ class AuthenticationComponentTest extends TestCase
      */
     public function testSetIdentity()
     {
-        $this->request = $this->request->withAttribute('authentication', $this->service);
+        $request = $this->request->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($this->request, $this->response);
+        $controller = new Controller($request, $this->response);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -139,10 +143,11 @@ class AuthenticationComponentTest extends TestCase
      */
     public function testGetIdentityData()
     {
-        $this->request = $this->request->withAttribute('identity', $this->identity);
-        $this->request = $this->request->withAttribute('authentication', $this->service);
+        $request = $this->request
+            ->withAttribute('identity', $this->identity)
+            ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($this->request, $this->response);
+        $controller = new Controller($request, $this->response);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -159,9 +164,9 @@ class AuthenticationComponentTest extends TestCase
      */
     public function testGetMissingIdentityData()
     {
-        $this->request = $this->request->withAttribute('authentication', $this->service);
+        $request = $this->request->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($this->request, $this->response);
+        $controller = new Controller($request, $this->response);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -175,10 +180,11 @@ class AuthenticationComponentTest extends TestCase
      */
     public function testGetResult()
     {
-        $this->request = $this->request->withAttribute('identity', $this->identity);
-        $this->request = $this->request->withAttribute('authentication', $this->service);
+        $request = $this->request
+            ->withAttribute('identity', $this->identity)
+            ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($this->request, $this->response);
+        $controller = new Controller($request, $this->response);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
         $this->assertNull($component->getResult());
@@ -196,10 +202,11 @@ class AuthenticationComponentTest extends TestCase
             $result = $event;
         });
 
-        $this->request = $this->request->withAttribute('identity', $this->identity);
-        $this->request = $this->request->withAttribute('authentication', $this->service);
+        $request = $this->request
+            ->withAttribute('identity', $this->identity)
+            ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($this->request, $this->response);
+        $controller = new Controller($request, $this->response);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -227,10 +234,11 @@ class AuthenticationComponentTest extends TestCase
             $this->response
         );
 
-        $this->request = $this->request->withAttribute('identity', $this->identity);
-        $this->request = $this->request->withAttribute('authentication', $this->service);
+        $request = $this->request
+            ->withAttribute('identity', $this->identity)
+            ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($this->request, $this->response);
+        $controller = new Controller($request, $this->response);
         $controller->loadComponent('Authentication.Authentication');
         $controller->startupProcess();
 

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -252,6 +252,37 @@ class AuthenticationComponentTest extends TestCase
     }
 
     /**
+     * test unauthenticated actions methods
+     *
+     * @return void
+     */
+    public function testUnauthenticatedActions()
+    {
+        $request = $this->request
+            ->withParam('action', 'view')
+            ->withAttribute('authentication', $this->service);
+
+        $controller = new Controller($request, $this->response);
+        $controller->loadComponent('Authentication.Authentication');
+
+        $controller->Authentication->allowUnauthenticated(['view']);
+        $this->assertSame(['view'], $controller->Authentication->getUnauthenticatedActions());
+
+        $controller->Authentication->allowUnauthenticated(['add', 'delete']);
+        $this->assertSame(['add', 'delete'], $controller->Authentication->getUnauthenticatedActions());
+
+        $controller->Authentication->addUnauthenticatedActions(['index']);
+        $this->assertSame(['add', 'delete', 'index'], $controller->Authentication->getUnauthenticatedActions());
+
+        $controller->Authentication->addUnauthenticatedActions(['index', 'view']);
+        $this->assertSame(
+            ['add', 'delete', 'index', 'view'],
+            $controller->Authentication->getUnauthenticatedActions(),
+            'Should contain unique set.'
+        );
+    }
+
+    /**
      * test unauthenticated actions ok
      *
      * @return void
@@ -266,7 +297,6 @@ class AuthenticationComponentTest extends TestCase
         $controller->loadComponent('Authentication.Authentication');
 
         $controller->Authentication->allowUnauthenticated(['view']);
-        $this->assertSame(['view'], $controller->Authentication->getUnauthenticatedActions());
         $controller->startupProcess();
         $this->assertTrue(true, 'No exception should be raised');
     }


### PR DESCRIPTION
This adds a *very* rudimentary form of access control to this plugin. By default the component will require an identity to be present in all requests. This behavior can be disabled via a setting or by using the `allowUnauthenticated()` method to whitelist the controller actions.

Refs #188