### PR TITLE
Add support for expanded cookies

### DIFF
--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -91,7 +91,11 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             ]);
         }
 
-        $token = json_decode($cookies[$cookieName], true);
+        if (is_array($cookies[$cookieName])) {
+            $token = $cookies[$cookieName];
+        } else {
+            $token = json_decode($cookies[$cookieName], true);
+        }
 
         if ($token === null || count($token) !== 2) {
             return new Result(null, Result::FAILURE_CREDENTIALS_INVALID, [

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -104,6 +104,34 @@ class CookieAuthenticatorTest extends TestCase
     }
 
     /**
+     * testAuthenticateSuccess
+     *
+     * @return void
+     */
+    public function testAuthenticateExpandedCookie()
+    {
+        $identifiers = new IdentifierCollection([
+            'Authentication.Password'
+        ]);
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/testpath'],
+            null,
+            null,
+            [
+                'CookieAuth' => ["mariano", "$2y$10$1bE1SgasKoz9WmEvUfuZLeYa6pQgxUIJ5LAoS/KGmC1hNuWkUG7ES"]
+            ]
+        );
+        $response = new Response();
+
+        $authenticator = new CookieAuthenticator($identifiers);
+        $result = $authenticator->authenticate($request, $response);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+    }
+
+    /**
      * testAuthenticateUnknownUser
      *
      * @return void


### PR DESCRIPTION
When using `EncryptedCookieMiddleware` cookies stored as a json string will be decoded after being decrypted. 

Refs https://github.com/cakephp/authentication/issues/194#issuecomment-379990583