### PR TITLE
Move Authentication service checks for early failures.

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -85,6 +85,14 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      */
     public function beforeFilter()
     {
+        if ($this->_authentication === null) {
+            throw new Exception('The request object does not contain the required `authentication` attribute');
+        }
+
+        if (!($this->_authentication instanceof AuthenticationServiceInterface)) {
+            throw new Exception('Authentication service does not implement ' . AuthenticationServiceInterface::class);
+        }
+
         $provider = $this->_authentication->getAuthenticationProvider();
 
         if ($provider === null ||
@@ -110,14 +118,6 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      */
     public function startup()
     {
-        if ($this->_authentication === null) {
-            throw new Exception('The request object does not contain the required `authentication` attribute');
-        }
-
-        if (!($this->_authentication instanceof AuthenticationServiceInterface)) {
-            throw new Exception('Authentication service does not implement ' . AuthenticationServiceInterface::class);
-        }
-
         if (!$this->getConfig('requireIdentity')) {
             return;
         }

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -82,7 +82,7 @@ class AuthenticationComponentTest extends TestCase
         $controller = new Controller($this->request, $this->response);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
-        $component->startup();
+        $component->beforeFilter();
     }
 
     /**
@@ -98,7 +98,7 @@ class AuthenticationComponentTest extends TestCase
         $controller = new Controller($request, $this->response);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
-        $component->startup();
+        $component->beforeFilter();
     }
 
     /**


### PR DESCRIPTION
`null` and `instanceof` checks should be executed early.