### PR TITLE
Use `302` instead of `301` for redirecting unauthenticated requests.

### DIFF
--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -125,7 +125,7 @@ class AuthenticationMiddleware
                 $url = $this->getRedirectUrl($target, $request);
 
                 return $response
-                    ->withStatus(301)
+                    ->withStatus(302)
                     ->withHeader('Location', $url);
             }
             throw $e;

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -438,7 +438,7 @@ class AuthenticationMiddlewareTest extends TestCase
         };
 
         $response = $middleware($request, $response, $next);
-        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('/users/login', $response->getHeaderLine('Location'));
         $this->assertSame('', $response->getBody() . '');
     }
@@ -467,7 +467,7 @@ class AuthenticationMiddlewareTest extends TestCase
         };
 
         $response = $middleware($request, $response, $next);
-        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('/users/login?redirect=http%3A%2F%2Flocalhost%2Ftestpath', $response->getHeaderLine('Location'));
         $this->assertSame('', $response->getBody() . '');
     }
@@ -496,7 +496,7 @@ class AuthenticationMiddlewareTest extends TestCase
         };
 
         $response = $middleware($request, $response, $next);
-        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('/users/login?hello=world&redirect=http%3A%2F%2Flocalhost%2Ftestpath', $response->getHeaderLine('Location'));
         $this->assertSame('', $response->getBody() . '');
     }


### PR DESCRIPTION
The location isn't permanently moved, therefore using `301` isn't appropriate.

I'd say this is generally problematic. In my specific case it prevented my custom authenticator from running on every non-login URL request, where it would need to apply some logic for things to work properly.