### PR TITLE
Add 401 status code to unauthenticated errors

### DIFF
--- a/src/Authenticator/UnauthenticatedException.php
+++ b/src/Authenticator/UnauthenticatedException.php
@@ -18,7 +18,25 @@ use RuntimeException;
 
 /**
  * An exception that signals that authentication was required but missing.
+ *
+ * This class cannot carry authentication challenge headers. This exception
+ * uses the 401 status code by default as this exception is used when the application
+ * has rejected a request but we do not know which authenticator the user should try.
  */
 class UnauthenticatedException extends RuntimeException
 {
+    /**
+     * Constructor
+     *
+     * @param string $message The exception message
+     * @param int $code The exception code that will be used as a HTTP status code
+     * @param \Exception|null $previous The previous exception or null
+     */
+    public function __construct($message = '', $code = 401, $previous = null)
+    {
+        if (!$message) {
+            $message = 'Authentication is required to continue';
+        }
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Authenticator/UnauthorizedException.php
+++ b/src/Authenticator/UnauthorizedException.php
@@ -18,6 +18,9 @@ use RuntimeException;
 
 /**
  * An exception that holds onto the headers/body for an unauthorized response.
+ *
+ * Unlike `UnauthenticatedException` this class can carry authentication challenge headers.
+ * and is used by stateless authenticators.
  */
 class UnauthorizedException extends RuntimeException
 {

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -355,6 +355,7 @@ class AuthenticationComponentTest extends TestCase
         $controller->loadComponent('Authentication.Authentication');
 
         $this->expectException(UnauthenticatedException::class);
+        $this->expectExceptionCode(401);
         $controller->Authentication->allowUnauthenticated(['index', 'add']);
         $controller->startupProcess();
     }
@@ -374,6 +375,7 @@ class AuthenticationComponentTest extends TestCase
         $controller->loadComponent('Authentication.Authentication');
 
         $this->expectException(UnauthenticatedException::class);
+        $this->expectExceptionCode(401);
         $controller->startupProcess();
     }
 

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -412,6 +412,7 @@ class AuthenticationMiddlewareTest extends TestCase
         };
 
         $this->expectException(UnauthenticatedException::class);
+        $this->expectExceptionCode(401);
         $middleware($request, $response, $next);
     }
 


### PR DESCRIPTION
Previously these responses would have 500 status code. Now they reflect a more reasonable status code. This is not a perfect solution as the 401 status code should contain a `WWW-Authorization` header value, but we don't currently have a way to fetch authenticators that could set the header correctly.

Fixes #223