### PR TITLE
Fix for correct ordering of hash and query params

### DIFF
--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -160,7 +160,7 @@ class AuthenticationMiddleware
 
         $hashPos = strpos($target, '#');
         if ($hashPos !== false) {
-            $query = $query . substr($target, $hashPos);
+            $query .= substr($target, $hashPos);
             $target = substr($target, 0, $hashPos);
         }
 

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -158,11 +158,11 @@ class AuthenticationMiddleware
             $query = '?' . $query;
         }
 
-		if( ($hashPos = strpos($target, '#')) !== false){
+        if (($hashPos = strpos($target, '#')) !== false) {
             $query = $query . substr($target, $hashPos);
             $target = substr($target, 0, $hashPos);
         }
-		
+        
         return $target . $query;
     }
 

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -158,6 +158,11 @@ class AuthenticationMiddleware
             $query = '?' . $query;
         }
 
+		if( ($hashPos = strpos($target, '#')) !== false){
+            $query = $query . substr($target, $hashPos);
+            $target = substr($target, 0, $hashPos);
+        }
+		
         return $target . $query;
     }
 

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -158,7 +158,8 @@ class AuthenticationMiddleware
             $query = '?' . $query;
         }
 
-        if (($hashPos = strpos($target, '#')) !== false) {
+        $hashPos = strpos($target, '#');
+        if ($hashPos !== false) {
             $query = $query . substr($target, $hashPos);
             $target = substr($target, 0, $hashPos);
         }

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -162,7 +162,7 @@ class AuthenticationMiddleware
             $query = $query . substr($target, $hashPos);
             $target = substr($target, 0, $hashPos);
         }
-        
+
         return $target . $query;
     }
 


### PR DESCRIPTION
Just as the title says.

I had an application which needed a hash parameter to show the login page. In addition with the 'redirect' query parameter the order was generated wrongly (URL#HASH?QUERY). 

According to [RFC 3986 Section 4.2](https://tools.ietf.org/html/rfc3986#section-4.2) 
> relative-ref  = relative-part [ "?" query ] [ "#" fragment ]

the order should be reversed. This PR does simply the following: if generated url contains a hash it gets split and joined reordered. 