### PR TITLE
Update identifiers.rst

### DIFF
--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -18,7 +18,7 @@ using the Password Identifier looks like::
        'passwordHasher' => [
            'className' => 'Authentication.Fallback',
            'hashers' => [
-               ['Authentication.Default'],
+               'Authentication.Default',
                [
                    'className' => 'Authentication.Legacy',
                    'hashType' => 'md5'


### PR DESCRIPTION
If Option Item hashers is a array it needs either have 'className' key or to be a string.