### PR TITLE
Renew session when ID when persisting/clearing identity.

### DIFF
--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -84,6 +84,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     public function persistIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity)
     {
         $sessionKey = $this->getConfig('sessionKey');
+        $request->getAttribute('session')->renew();
         $request->getAttribute('session')->write($sessionKey, $identity);
 
         return [
@@ -99,6 +100,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     {
         $sessionKey = $this->getConfig('sessionKey');
         $request->getAttribute('session')->delete($sessionKey);
+        $request->getAttribute('session')->renew();
 
         return [
             'request' => $request->withoutAttribute($this->getConfig('identityAttribute')),

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -54,7 +54,7 @@ class SessionAuthenticatorTest extends TestCase
         }
         $this->sessionMock = $this->getMockBuilder($class)
             ->disableOriginalConstructor()
-            ->setMethods(['read', 'write', 'delete'])
+            ->setMethods(['read', 'write', 'delete', 'renew'])
             ->getMock();
     }
 
@@ -158,7 +158,11 @@ class SessionAuthenticatorTest extends TestCase
         $authenticator = new SessionAuthenticator($this->identifiers);
 
         $data = new ArrayObject(['username' => 'florian']);
-        $this->sessionMock->expects($this->at(0))
+        $this->sessionMock
+            ->expects($this->at(0))
+            ->method('renew');
+
+        $this->sessionMock->expects($this->at(1))
             ->method('write')
             ->with('Auth', $data);
 
@@ -186,6 +190,10 @@ class SessionAuthenticatorTest extends TestCase
         $this->sessionMock->expects($this->at(0))
             ->method('delete')
             ->with('Auth');
+
+        $this->sessionMock
+            ->expects($this->at(1))
+            ->method('renew');
 
         $result = $authenticator->clearIdentity($request, $response);
         $this->assertInternalType('array', $result);


### PR DESCRIPTION
See https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Session_Management_Cheat_Sheet.md#renew-the-session-id-after-any-privilege-level-change

A user reported to @chinpei215 that the new authen lib didn't renew session ID like the core `AuthComponent`.