### PR TITLE
Add "Quick Start" to menu

### DIFF
--- a/docs/en/contents.rst
+++ b/docs/en/contents.rst
@@ -5,6 +5,7 @@ Contents
     :maxdepth: 2
     :caption: CakePHP Authentication
 
+    /index
     /authenticators
     /identifiers
     /password-hashers


### PR DESCRIPTION
The "Quick Start" is missing from the left menu.