### PR TITLE
phpdoc with return type for method IdentifierCollection::get($name)

### DIFF
--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -18,6 +18,10 @@ use Authentication\AbstractCollection;
 use Cake\Core\App;
 use RuntimeException;
 
+/**
+ * Class IdentifierCollection
+ * @method \Authentication\Identifier\IdentifierInterface get($name)
+ */
 class IdentifierCollection extends AbstractCollection implements IdentifierInterface
 {
 

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -20,7 +20,7 @@ use RuntimeException;
 
 /**
  * Class IdentifierCollection
- * @method \Authentication\Identifier\IdentifierInterface get($name)
+ * @method \Authentication\Identifier\IdentifierInterface|null get($name)
  */
 class IdentifierCollection extends AbstractCollection implements IdentifierInterface
 {

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -19,7 +19,7 @@ use Cake\Core\App;
 use RuntimeException;
 
 /**
- * @method \Authentication\Identifier\IdentifierInterface|null get($name)
+ * @method \Authentication\Identifier\IdentifierInterface|null get(string $name)
  */
 class IdentifierCollection extends AbstractCollection implements IdentifierInterface
 {

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -19,7 +19,6 @@ use Cake\Core\App;
 use RuntimeException;
 
 /**
- * Class IdentifierCollection
  * @method \Authentication\Identifier\IdentifierInterface|null get($name)
  */
 class IdentifierCollection extends AbstractCollection implements IdentifierInterface


### PR DESCRIPTION
Enables autocomplete for following code:
$authService = $this->Authentication->getAuthenticationService();
$errors = $authService ->identifiers()->get('Password')->getErrors()