### PR TITLE
Add php doc for method AuthenticatorCollection::get($name) and fix message for RuntimeException

### DIFF
--- a/src/Authenticator/AuthenticatorCollection.php
+++ b/src/Authenticator/AuthenticatorCollection.php
@@ -21,7 +21,7 @@ use RuntimeException;
 
 /**
  * Class AuthenticatorCollection
- * @method \Authentication\Authenticator\AuthenticatorInterface get($name)
+ * @method \Authentication\Authenticator\AuthenticatorInterface|null get($name)
  */
 class AuthenticatorCollection extends AbstractCollection
 {

--- a/src/Authenticator/AuthenticatorCollection.php
+++ b/src/Authenticator/AuthenticatorCollection.php
@@ -20,7 +20,7 @@ use Cake\Core\App;
 use RuntimeException;
 
 /**
- * @method \Authentication\Authenticator\AuthenticatorInterface|null get($name)
+ * @method \Authentication\Authenticator\AuthenticatorInterface|null get(string $name)
  */
 class AuthenticatorCollection extends AbstractCollection
 {

--- a/src/Authenticator/AuthenticatorCollection.php
+++ b/src/Authenticator/AuthenticatorCollection.php
@@ -20,7 +20,6 @@ use Cake\Core\App;
 use RuntimeException;
 
 /**
- * Class AuthenticatorCollection
  * @method \Authentication\Authenticator\AuthenticatorInterface|null get($name)
  */
 class AuthenticatorCollection extends AbstractCollection

--- a/src/Authenticator/AuthenticatorCollection.php
+++ b/src/Authenticator/AuthenticatorCollection.php
@@ -19,6 +19,10 @@ use Authentication\Identifier\IdentifierCollection;
 use Cake\Core\App;
 use RuntimeException;
 
+/**
+ * Class AuthenticatorCollection
+ * @method \Authentication\Authenticator\AuthenticatorInterface get($name)
+ */
 class AuthenticatorCollection extends AbstractCollection
 {
     /**
@@ -55,8 +59,9 @@ class AuthenticatorCollection extends AbstractCollection
         $authenticator = new $className($this->_identifiers, $config);
         if (!($authenticator instanceof AuthenticatorInterface)) {
             throw new RuntimeException(sprintf(
-                'Authenticator class `%s` must implement \Auth\Authentication\AuthenticatorInterface',
-                $className
+                'Authenticator class `%s` must implement `%s`.',
+                $className,
+                AuthenticatorInterface::class
             ));
         }
 

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -135,7 +135,7 @@ class AuthenticationServiceTest extends TestCase
      * testLoadInvalidAuthenticatorObject
      *
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Authenticator class `TestApp\Authentication\Authenticator\InvalidAuthenticator` must implement \Auth\Authentication\AuthenticatorInterface
+     * @expectedExceptionMessage Authenticator class `TestApp\Authentication\Authenticator\InvalidAuthenticator` must implement `Authentication\Authenticator\AuthenticatorInterface`.
      */
     public function testLoadInvalidAuthenticatorObject()
     {


### PR DESCRIPTION
RuntimeException message had invalid namespace '\Auth\Authentication', should be '\Authentication\Authenticator'.
Phpdoc enables autocomplete:
$authService = $this->Authentication->getAuthenticationService();
$authenticator = $authService->authenticators()->get('Form');
$result = $authenticator->authenticate($request, $response)