### PR TITLE
Fix session rotation on each request

### DIFF
--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -84,8 +84,11 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     public function persistIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity)
     {
         $sessionKey = $this->getConfig('sessionKey');
-        $request->getAttribute('session')->renew();
-        $request->getAttribute('session')->write($sessionKey, $identity);
+        $session = $request->getAttribute('session');
+        if (!$session->check($sessionKey)) {
+            $session->renew();
+            $session->write($sessionKey, $identity);
+        }
 
         return [
             'request' => $request,
@@ -99,8 +102,9 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     public function clearIdentity(ServerRequestInterface $request, ResponseInterface $response)
     {
         $sessionKey = $this->getConfig('sessionKey');
-        $request->getAttribute('session')->delete($sessionKey);
-        $request->getAttribute('session')->renew();
+        $session = $request->getAttribute('session');
+        $session->delete($sessionKey);
+        $session->renew();
 
         return [
             'request' => $request->withoutAttribute($this->getConfig('identityAttribute')),

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -12,7 +12,7 @@
  * @since         1.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Authentication\Test\TestCase\Authenticator;
+namespace Authentication\Test\TestCase;
 
 use ArrayObject;
 use Authentication\AuthenticationService;
@@ -65,8 +65,8 @@ class AuthenticationServiceTest extends TestCase
                 'Authentication.Password'
             ],
             'authenticators' => [
+                'Authentication.Form',
                 'Authentication.Session',
-                'Authentication.Form'
             ]
         ]);
 


### PR DESCRIPTION
The changes from #271 were not backported to 1.x and thus when authentication and SecurityComponent were combined every request would fail.

Fixes #284