### PR TITLE
Move redirect configuration to the service

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -344,7 +344,7 @@ class AuthenticationService implements AuthenticationServiceInterface
      * If the `queryParam` option is set a query parameter
      * will be appended with the denied URL path.
      *
-     * @param Psr\Http\Message\ServerRequestInterface $request The request
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
      * @return string|null
      */
     public function getUnauthenticatedRedirectUrl(ServerRequestInterface $request)

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -79,6 +79,11 @@ class AuthenticationService implements AuthenticationServiceInterface
      *      ]
      *   ]);
      *   ```
+     * - `identityAttribute` - The request attribute to store the identity in.
+     * - `unauthenticatedRedirect` - The URL to redirect unauthenticated errors to. See
+     *    AuthenticationComponent::allowUnauthenticated()
+     * - `queryParam` - Set to a string to have unauthenticated redirects contain a `redirect` query string
+     *   parameter with the previously blocked URL.
      *
      * @var array
      */
@@ -87,6 +92,8 @@ class AuthenticationService implements AuthenticationServiceInterface
         'identifiers' => [],
         'identityClass' => Identity::class,
         'identityAttribute' => 'identity',
+        'queryParam' => null,
+        'unauthorizedRedirect' => null,
     ];
 
     /**
@@ -292,6 +299,16 @@ class AuthenticationService implements AuthenticationServiceInterface
     }
 
     /**
+     * Return the name of the identity attribute.
+     *
+     * @return string
+     */
+    public function getIdentityAttribute()
+    {
+        return $this->getConfig('identityAttribute');
+    }
+
+    /**
      * Builds the identity object
      *
      * @param \ArrayAccess|array $identityData Identity data
@@ -316,5 +333,49 @@ class AuthenticationService implements AuthenticationServiceInterface
         }
 
         return $identity;
+    }
+
+    /**
+     * Return the URL to redirect unauthenticated users to.
+     *
+     * If the `unauthenticaedRedirect` option is not set,
+     * this method will return null.
+     *
+     * If the `queryParam` option is set a query parameter
+     * will be appended with the denied URL path.
+     *
+     * @param Psr\Http\Message\ServerRequestInterface $request The request
+     * @return string|null
+     */
+    public function getUnauthenticatedRedirectUrl(ServerRequestInterface $request)
+    {
+        $param = $this->getConfig('queryParam');
+        $target = $this->getConfig('unauthenticatedRedirect');
+        if ($target === null) {
+            return null;
+        }
+        if ($param === null) {
+            return $target;
+        }
+
+        $uri = $request->getUri();
+        if (property_exists($uri, 'base')) {
+            $uri = $uri->withPath($uri->base . $uri->getPath());
+        }
+        $redirect = $uri->getPath();
+        if ($uri->getQuery()) {
+            $redirect .= '?' . $uri->getQuery();
+        }
+        $query = urlencode($param) . '=' . urlencode($redirect);
+
+        $url = parse_url($target);
+        if (isset($url['query']) && strlen($url['query'])) {
+            $url['query'] .= '&' . $query;
+        } else {
+            $url['query'] = $query;
+        }
+        $fragment = isset($url['fragment']) ? '#' . $url['fragment'] : '';
+
+        return $url['path'] . '?' . $url['query'] . $fragment;
     }
 }

--- a/src/AuthenticationServiceInterface.php
+++ b/src/AuthenticationServiceInterface.php
@@ -69,4 +69,19 @@ interface AuthenticationServiceInterface extends PersistenceInterface
      * @return \Authentication\Authenticator\ResultInterface|null Authentication result interface
      */
     public function getResult();
+
+    /**
+     * Return the name of the identity attribute.
+     *
+     * @return string
+     */
+    public function getIdentityAttribute();
+
+    /**
+     * Return the URL to redirect unauthenticated users to.
+     *
+     * @param Psr\Http\Message\ServerRequestInterface $request The request
+     * @return string|null
+     */
+    public function getUnauthenticatedRedirectUrl(ServerRequestInterface $request);
 }

--- a/src/AuthenticationServiceInterface.php
+++ b/src/AuthenticationServiceInterface.php
@@ -80,7 +80,7 @@ interface AuthenticationServiceInterface extends PersistenceInterface
     /**
      * Return the URL to redirect unauthenticated users to.
      *
-     * @param Psr\Http\Message\ServerRequestInterface $request The request
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
      * @return string|null
      */
     public function getUnauthenticatedRedirectUrl(ServerRequestInterface $request);

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -14,6 +14,7 @@
  */
 namespace Authentication\Middleware;
 
+use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\AuthenticationServiceProviderInterface;
 use Authentication\Authenticator\UnauthenticatedException;
@@ -160,7 +161,7 @@ class AuthenticationMiddleware
                     "The `{$key}` configuration key on AuthenticationMiddleware is deprecated. " .
                     "Instead set the `{$key}` on your AuthenticationService instance."
                 );
-                if (method_exists($subject, 'setConfig')) {
+                if ($subject instanceof AuthenticationService) {
                     $subject->setConfig($key, $value);
                 } else {
                     throw new RuntimeException(

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -646,7 +646,7 @@ class AuthenticationServiceTest extends TestCase
     {
         $service = new AuthenticationService();
         $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/secrets'],
+            ['REQUEST_URI' => '/secrets']
         );
         $service->setConfig('unauthenticatedRedirect', '/users/login');
         $this->assertSame('/users/login', $service->getUnauthenticatedRedirectUrl($request));

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -673,7 +673,7 @@ class AuthenticationServiceTest extends TestCase
     public function testGetUnauthenticatedRedirectUrlWithBasePath()
     {
         $request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/secrets'],
+            ['REQUEST_URI' => '/secrets']
         );
         $uri = $request->getUri();
         $uri->base = '/base';


### PR DESCRIPTION
Moving redirect configuration and identityAttribute configuration allows application code to be more DRY and centralize configuration. Doing so requires a few new public methods as I didn't feel like adding `getConfig()` to the interface was a good idea.

Another benefit of moving then `unauthorizedRedirect` option is that users can use `Router::url()` to generate the target. Right now URLs must be a string which makes applications in sub directories more painful.

These changes will mostly backwards compatible as long as the application isn't using a custom service implementation.