### PR TITLE
1.1.x Revert session rotate

### DIFF
--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -84,11 +84,8 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     public function persistIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity)
     {
         $sessionKey = $this->getConfig('sessionKey');
-        $session = $request->getAttribute('session');
-        if (!$session->check($sessionKey)) {
-            $session->renew();
-            $session->write($sessionKey, $identity);
-        }
+        $request->getAttribute('session')->renew();
+        $request->getAttribute('session')->write($sessionKey, $identity);
 
         return [
             'request' => $request,
@@ -102,9 +99,8 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     public function clearIdentity(ServerRequestInterface $request, ResponseInterface $response)
     {
         $sessionKey = $this->getConfig('sessionKey');
-        $session = $request->getAttribute('session');
-        $session->delete($sessionKey);
-        $session->renew();
+        $request->getAttribute('session')->delete($sessionKey);
+        $request->getAttribute('session')->renew();
 
         return [
             'request' => $request->withoutAttribute($this->getConfig('identityAttribute')),

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -84,7 +84,6 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     public function persistIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity)
     {
         $sessionKey = $this->getConfig('sessionKey');
-        $request->getAttribute('session')->renew();
         $request->getAttribute('session')->write($sessionKey, $identity);
 
         return [
@@ -100,7 +99,6 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     {
         $sessionKey = $this->getConfig('sessionKey');
         $request->getAttribute('session')->delete($sessionKey);
-        $request->getAttribute('session')->renew();
 
         return [
             'request' => $request->withoutAttribute($this->getConfig('identityAttribute')),

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -12,7 +12,7 @@
  * @since         1.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Authentication\Test\TestCase;
+namespace Authentication\Test\TestCase\Authenticator;
 
 use ArrayObject;
 use Authentication\AuthenticationService;
@@ -65,8 +65,8 @@ class AuthenticationServiceTest extends TestCase
                 'Authentication.Password'
             ],
             'authenticators' => [
-                'Authentication.Form',
                 'Authentication.Session',
+                'Authentication.Form'
             ]
         ]);
 

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -12,7 +12,7 @@
  * @since         1.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Authentication\Test\TestCase\Authenticator;
+namespace Authentication\Test\TestCase;
 
 use ArrayObject;
 use Authentication\AuthenticationService;

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -54,7 +54,7 @@ class SessionAuthenticatorTest extends TestCase
         }
         $this->sessionMock = $this->getMockBuilder($class)
             ->disableOriginalConstructor()
-            ->setMethods(['read', 'write', 'delete', 'renew'])
+            ->setMethods(['read', 'write', 'delete'])
             ->getMock();
     }
 
@@ -158,11 +158,7 @@ class SessionAuthenticatorTest extends TestCase
         $authenticator = new SessionAuthenticator($this->identifiers);
 
         $data = new ArrayObject(['username' => 'florian']);
-        $this->sessionMock
-            ->expects($this->at(0))
-            ->method('renew');
-
-        $this->sessionMock->expects($this->at(1))
+        $this->sessionMock->expects($this->at(0))
             ->method('write')
             ->with('Auth', $data);
 
@@ -190,10 +186,6 @@ class SessionAuthenticatorTest extends TestCase
         $this->sessionMock->expects($this->at(0))
             ->method('delete')
             ->with('Auth');
-
-        $this->sessionMock
-            ->expects($this->at(1))
-            ->method('renew');
 
         $result = $authenticator->clearIdentity($request, $response);
         $this->assertInternalType('array', $result);

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -54,7 +54,7 @@ class SessionAuthenticatorTest extends TestCase
         }
         $this->sessionMock = $this->getMockBuilder($class)
             ->disableOriginalConstructor()
-            ->setMethods(['read', 'write', 'delete', 'renew', 'check'])
+            ->setMethods(['read', 'write', 'delete', 'renew'])
             ->getMock();
     }
 
@@ -160,24 +160,11 @@ class SessionAuthenticatorTest extends TestCase
         $data = new ArrayObject(['username' => 'florian']);
         $this->sessionMock
             ->expects($this->at(0))
-            ->method('check')
-            ->with('Auth')
-            ->will($this->returnValue(false));
-
-        $this->sessionMock
-            ->expects($this->once())
             ->method('renew');
 
-        $this->sessionMock
-            ->expects($this->once())
+        $this->sessionMock->expects($this->at(1))
             ->method('write')
             ->with('Auth', $data);
-
-        $this->sessionMock
-            ->expects($this->at(3))
-            ->method('check')
-            ->with('Auth')
-            ->will($this->returnValue(true));
 
         $result = $authenticator->persistIdentity($request, $response, $data);
         $this->assertInternalType('array', $result);
@@ -185,9 +172,6 @@ class SessionAuthenticatorTest extends TestCase
         $this->assertArrayHasKey('response', $result);
         $this->assertInstanceOf(RequestInterface::class, $result['request']);
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
-
-        // Persist again to make sure identity isn't replaced if it exists.
-        $authenticator->persistIdentity($request, $response, new ArrayObject(['username' => 'jane']));
     }
 
     /**


### PR DESCRIPTION
Revert the session rotation changes made in 1.1.3 and attempted fix made in 1.1.4. This re-opens the possibility for a session fixation but restores compatibility with SecurityComponent.

If merged this would become 1.1.5. The changes in #286 would become 1.2.0. Those changes don't break an API contracts and the minor change in behavior should be ok in a minor release where we can document what changed.