### PR TITLE
Fix logout with session authentication

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -218,6 +218,7 @@ class AuthenticationService implements AuthenticationServiceInterface
                 $response = $result['response'];
             }
         }
+        $this->_successfulAuthenticator = null;
 
         return [
             'request' => $request->withoutAttribute($this->getConfig('identityAttribute')),


### PR DESCRIPTION
When using the session authenticator one could never logout. Because the
session authenticator would be the 'authentication provider' for the
current request, it would have data re-persisted by the middleware after
the wrapped middleware (including the controller) were complete. By
clearing the authentication provider we skip this loop.

Backport #265 to master