### PR TITLE
#283: Authenticator and Identifier in Result

### DIFF
--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -90,7 +90,7 @@ class FormAuthenticator extends AbstractAuthenticator
             )
         ];
 
-        return new Result(null, Result::FAILURE_OTHER, $errors);
+        return new Result(null, Result::FAILURE_OTHER, $errors, null, $this);
     }
 
     /**
@@ -112,15 +112,27 @@ class FormAuthenticator extends AbstractAuthenticator
         if ($data === null) {
             return new Result(null, Result::FAILURE_CREDENTIALS_MISSING, [
                 'Login credentials not found'
-            ]);
+            ], null, $this);
         }
 
         $user = $this->_identifier->identify($data);
 
         if (empty($user)) {
-            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
+            return new Result(
+                null,
+                Result::FAILURE_IDENTITY_NOT_FOUND,
+                $this->_identifier->getErrors(),
+                $this->_identifier->getSuccessfulIdentifier(),
+                $this
+            );
         }
 
-        return new Result($user, Result::SUCCESS);
+        return new Result(
+            $user,
+            Result::SUCCESS,
+            [],
+            $this->_identifier->getSuccessfulIdentifier(),
+            $this
+        );
     }
 }

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -38,10 +38,10 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
         $user = $this->getUser($request);
 
         if (empty($user)) {
-            return new Result(null, Result::FAILURE_CREDENTIALS_MISSING);
+            return new Result(null, Result::FAILURE_CREDENTIALS_MISSING, [], null, $this);
         }
 
-        return new Result($user, Result::SUCCESS);
+        return new Result($user, Result::SUCCESS, [], $this->_identifier->getSuccessfulIdentifier(), $this);
     }
 
     /**

--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -91,7 +91,7 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
     {
         $digest = $this->_getDigest($request);
         if ($digest === null) {
-            return new Result(null, Result::FAILURE_CREDENTIALS_MISSING);
+            return new Result(null, Result::FAILURE_CREDENTIALS_MISSING, [], null, $this);
         }
 
         $user = $this->_identifier->identify([
@@ -99,11 +99,11 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
         ]);
 
         if (empty($user)) {
-            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
+            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, [], $this->_identifier->getSuccessfulIdentifier(), $this);
         }
 
         if (!$this->validNonce($digest['nonce'])) {
-            return new Result(null, Result::FAILURE_CREDENTIALS_INVALID);
+            return new Result(null, Result::FAILURE_CREDENTIALS_INVALID, [], $this->_identifier->getSuccessfulIdentifier(), $this);
         }
 
         $field = $this->_config['fields'][IdentifierInterface::CREDENTIAL_PASSWORD];
@@ -116,10 +116,10 @@ class HttpDigestAuthenticator extends HttpBasicAuthenticator
 
         $hash = $this->generateResponseHash($digest, $password, $server['ORIGINAL_REQUEST_METHOD']);
         if (hash_equals($hash, $digest['response'])) {
-            return new Result($user, Result::SUCCESS);
+            return new Result($user, Result::SUCCESS, [], $this->_identifier->getSuccessfulIdentifier(), $this);
         }
 
-        return new Result(null, Result::FAILURE_CREDENTIALS_INVALID);
+        return new Result(null, Result::FAILURE_CREDENTIALS_INVALID, [], $this->_identifier->getSuccessfulIdentifier(), $this);
     }
 
     /**

--- a/src/Authenticator/Result.php
+++ b/src/Authenticator/Result.php
@@ -141,6 +141,7 @@ class Result implements ResultInterface
 
     /**
      * set the identifier who match the correct identity or null
+     * @param null|Authentication\Identifier\IdentifierInterface $identifier The matching identifier
      * @return void
      */
     public function setIdentifier(IdentifierInterface $identifier = null)
@@ -159,6 +160,7 @@ class Result implements ResultInterface
 
     /**
      * set the authenticator who match the correct identity or null
+     * @param null|Authentication\Authenticator\AuthenticatorInterface $authenticator The matching authenticator
      * @return void
      */
     public function setAuthenticator(AuthenticatorInterface $authenticator = null)

--- a/src/Authenticator/Result.php
+++ b/src/Authenticator/Result.php
@@ -66,7 +66,7 @@ class Result implements ResultInterface
      * @param array $messages Messages.
      * @throws \InvalidArgumentException When invalid identity data is passed.
      */
-    public function __construct($data, $status, array $messages = [])
+    public function __construct($data, $status, array $messages = [], IdentifierInterface $identifier = null, AuthenticatorInterface $authenticator = null)
     {
         if ($status === self::SUCCESS && empty($data)) {
             throw new InvalidArgumentException('Identity data can not be empty with status success.');
@@ -83,6 +83,9 @@ class Result implements ResultInterface
         $this->_status = $status;
         $this->_data = $data;
         $this->_errors = $messages;
+
+        $this->_identifier = $identifier;
+        $this->_authenticator = $authenticator;
     }
 
     /**

--- a/src/Authenticator/Result.php
+++ b/src/Authenticator/Result.php
@@ -47,19 +47,19 @@ class Result implements ResultInterface
     protected $_errors = [];
 
     /**
-     * successful identifier or null
+     * Successful identifier or null.
      * @var \Authentication\Identifier\IdentifierInterface|null
      */
     protected $_identifier = null;
 
     /**
-     * successful authenticator or null
+     * Successful authenticator or null.
      * @var \Authentication\Authenticator\AuthenticatorInterface|null
      */
     protected $_authenticator = null;
 
     /**
-     * Sets the result status, identity, and failure messages
+     * Sets the result status, identity, failure messages, successful identifier and authenticator.
      *
      * @param null|array|\ArrayAccess $data The identity data
      * @param string $status Status constant equivalent.
@@ -85,7 +85,6 @@ class Result implements ResultInterface
         $this->_status = $status;
         $this->_data = $data;
         $this->_errors = $messages;
-
         $this->_identifier = $identifier;
         $this->_authenticator = $authenticator;
     }
@@ -133,7 +132,7 @@ class Result implements ResultInterface
     }
 
     /**
-     * return null or the identifier who match the correct identity
+     * Return null or the identifier who match the correct identity.
      * @return \Authentication\Identifier\IdentifierInterface|null
      */
     public function getIdentifier()
@@ -142,8 +141,8 @@ class Result implements ResultInterface
     }
 
     /**
-     * set the identifier who match the correct identity or null
-     * @param \Authentication\Identifier\IdentifierInterface|null $identifier The matching identifier
+     * Set the identifier who match the correct identity or null.
+     * @param \Authentication\Identifier\IdentifierInterface|null $identifier The matching identifier.
      * @return void
      */
     public function setIdentifier(IdentifierInterface $identifier = null)
@@ -152,7 +151,7 @@ class Result implements ResultInterface
     }
 
     /**
-     * return null or the authenticator who match the correct identity
+     * Return null or the authenticator who match the correct identity.
      * @return \Authentication\Authenticator\AuthenticatorInterface|null
      */
     public function getAuthenticator()
@@ -161,8 +160,8 @@ class Result implements ResultInterface
     }
 
     /**
-     * set the authenticator who match the correct identity or null
-     * @param \Authentication\Authenticator\AuthenticatorInterface|null $authenticator The matching authenticator
+     * Set the authenticator who match the correct identity or null.
+     * @param \Authentication\Authenticator\AuthenticatorInterface|null $authenticator The matching authenticator.
      * @return void
      */
     public function setAuthenticator(AuthenticatorInterface $authenticator = null)

--- a/src/Authenticator/Result.php
+++ b/src/Authenticator/Result.php
@@ -64,6 +64,8 @@ class Result implements ResultInterface
      * @param null|array|\ArrayAccess $data The identity data
      * @param string $status Status constant equivalent.
      * @param array $messages Messages.
+     * @param \Authentication\Identifier\IdentifierInterface|null $identifier The matching identifier.
+     * @param \Authentication\Authenticator\AuthenticatorInterface|null $authenticator The matching authenticator.
      * @throws \InvalidArgumentException When invalid identity data is passed.
      */
     public function __construct($data, $status, array $messages = [], IdentifierInterface $identifier = null, AuthenticatorInterface $authenticator = null)
@@ -132,7 +134,7 @@ class Result implements ResultInterface
 
     /**
      * return null or the identifier who match the correct identity
-     * @return null|Authentication\Identifier\IdentifierInterface
+     * @return \Authentication\Identifier\IdentifierInterface|null
      */
     public function getIdentifier()
     {
@@ -141,7 +143,7 @@ class Result implements ResultInterface
 
     /**
      * set the identifier who match the correct identity or null
-     * @param null|Authentication\Identifier\IdentifierInterface $identifier The matching identifier
+     * @param \Authentication\Identifier\IdentifierInterface|null $identifier The matching identifier
      * @return void
      */
     public function setIdentifier(IdentifierInterface $identifier = null)
@@ -151,7 +153,7 @@ class Result implements ResultInterface
 
     /**
      * return null or the authenticator who match the correct identity
-     * @return null|Authentication\Authenticator\AuthenticatorInterface
+     * @return \Authentication\Authenticator\AuthenticatorInterface|null
      */
     public function getAuthenticator()
     {
@@ -160,7 +162,7 @@ class Result implements ResultInterface
 
     /**
      * set the authenticator who match the correct identity or null
-     * @param null|Authentication\Authenticator\AuthenticatorInterface $authenticator The matching authenticator
+     * @param \Authentication\Authenticator\AuthenticatorInterface|null $authenticator The matching authenticator
      * @return void
      */
     public function setAuthenticator(AuthenticatorInterface $authenticator = null)

--- a/src/Authenticator/Result.php
+++ b/src/Authenticator/Result.php
@@ -53,6 +53,12 @@ class Result implements ResultInterface
     protected $_identifier = null;
 
     /**
+     * successful authenticator or null
+     * @var null|Authentication\Authenticator\AuthenticatorInterface
+     */
+    protected $_authenticator = null;
+
+    /**
      * Sets the result status, identity, and failure messages
      *
      * @param null|array|\ArrayAccess $data The identity data
@@ -137,5 +143,23 @@ class Result implements ResultInterface
     public function setIdentifier(IdentifierInterface $identifier = null)
     {
         $this->_identifier = $identifier;
+    }
+
+    /**
+     * return null or the authenticator who match the correct identity
+     * @return null|Authentication\Authenticator\AuthenticatorInterface
+     */
+    public function getAuthenticator()
+    {
+        return $this->_authenticator;
+    }
+
+    /**
+     * set the authenticator who match the correct identity or null
+     * @return void
+     */
+    public function setAuthenticator(AuthenticatorInterface $authenticator = null)
+    {
+        $this->_authenticator = $authenticator;
     }
 }

--- a/src/Authenticator/Result.php
+++ b/src/Authenticator/Result.php
@@ -15,6 +15,7 @@
 namespace Authentication\Authenticator;
 
 use ArrayAccess;
+use Authentication\Identifier\IdentifierInterface;
 use InvalidArgumentException;
 
 /**
@@ -44,6 +45,12 @@ class Result implements ResultInterface
      * @var array
      */
     protected $_errors = [];
+
+    /**
+     * successful identifier or null
+     * @var null|Authentication\Identifier\IdentifierInterface
+     */
+    protected $_identifier = null;
 
     /**
      * Sets the result status, identity, and failure messages
@@ -112,5 +119,23 @@ class Result implements ResultInterface
     public function getErrors()
     {
         return $this->_errors;
+    }
+
+    /**
+     * return null or the identifier who match the correct identity
+     * @return null|Authentication\Identifier\IdentifierInterface
+     */
+    public function getIdentifier()
+    {
+        return $this->_identifier;
+    }
+
+    /**
+     * set the identifier who match the correct identity or null
+     * @return void
+     */
+    public function setIdentifier(IdentifierInterface $identifier = null)
+    {
+        $this->_identifier = $identifier;
     }
 }

--- a/src/Authenticator/Result.php
+++ b/src/Authenticator/Result.php
@@ -48,13 +48,13 @@ class Result implements ResultInterface
 
     /**
      * successful identifier or null
-     * @var null|Authentication\Identifier\IdentifierInterface
+     * @var \Authentication\Identifier\IdentifierInterface|null
      */
     protected $_identifier = null;
 
     /**
      * successful authenticator or null
-     * @var null|Authentication\Authenticator\AuthenticatorInterface
+     * @var \Authentication\Authenticator\AuthenticatorInterface|null
      */
     protected $_authenticator = null;
 

--- a/src/Authenticator/ResultInterface.php
+++ b/src/Authenticator/ResultInterface.php
@@ -14,6 +14,8 @@
  */
 namespace Authentication\Authenticator;
 
+use Authentication\Identifier\IdentifierInterface;
+
 interface ResultInterface
 {
     /**
@@ -79,9 +81,10 @@ interface ResultInterface
 
     /**
      * set the identifier who match the correct identity or null
+     * @param null|Authentication\Identifier\IdentifierInterface $identifier The matching identifier
      * @return void
      */
-    public function setIdentifier();
+    public function setIdentifier(IdentifierInterface $identifier = null);
 
     /**
      * return null or the authenticator who match the correct identity
@@ -91,7 +94,8 @@ interface ResultInterface
 
     /**
      * set the authenticator who match the correct identity or null
+     * @param null|Authentication\Authenticator\AuthenticatorInterface $authenticator The matching authenticator
      * @return void
      */
-    public function setAuthenticator();
+    public function setAuthenticator(AuthenticatorInterface $authenticator = null);
 }

--- a/src/Authenticator/ResultInterface.php
+++ b/src/Authenticator/ResultInterface.php
@@ -75,26 +75,26 @@ interface ResultInterface
 
     /**
      * return null or the identifier who match the correct identity
-     * @return null|Authentication\Identifier\IdentifierInterface
+     * @return \Authentication\Identifier\IdentifierInterface|null
      */
     public function getIdentifier();
 
     /**
      * set the identifier who match the correct identity or null
-     * @param null|Authentication\Identifier\IdentifierInterface $identifier The matching identifier
+     * @param \Authentication\Identifier\IdentifierInterface|null $identifier The matching identifier
      * @return void
      */
     public function setIdentifier(IdentifierInterface $identifier = null);
 
     /**
      * return null or the authenticator who match the correct identity
-     * @return null|Authentication\Authenticator\AuthenticatorInterface
+     * @return \Authentication\Authenticator\AuthenticatorInterface|null
      */
     public function getAuthenticator();
 
     /**
      * set the authenticator who match the correct identity or null
-     * @param null|Authentication\Authenticator\AuthenticatorInterface $authenticator The matching authenticator
+     * @param \Authentication\Authenticator\AuthenticatorInterface|null $authenticator The matching authenticator
      * @return void
      */
     public function setAuthenticator(AuthenticatorInterface $authenticator = null);

--- a/src/Authenticator/ResultInterface.php
+++ b/src/Authenticator/ResultInterface.php
@@ -82,4 +82,16 @@ interface ResultInterface
      * @return void
      */
     public function setIdentifier();
+
+    /**
+     * return null or the authenticator who match the correct identity
+     * @return null|Authentication\Authenticator\AuthenticatorInterface
+     */
+    public function getAuthenticator();
+
+    /**
+     * set the authenticator who match the correct identity or null
+     * @return void
+     */
+    public function setAuthenticator();
 }

--- a/src/Authenticator/ResultInterface.php
+++ b/src/Authenticator/ResultInterface.php
@@ -70,4 +70,16 @@ interface ResultInterface
      * @return array
      */
     public function getErrors();
+
+    /**
+     * return null or the identifier who match the correct identity
+     * @return null|Authentication\Identifier\IdentifierInterface
+     */
+    public function getIdentifier();
+
+    /**
+     * set the identifier who match the correct identity or null
+     * @return void
+     */
+    public function setIdentifier();
 }

--- a/src/Authenticator/ResultInterface.php
+++ b/src/Authenticator/ResultInterface.php
@@ -74,27 +74,27 @@ interface ResultInterface
     public function getErrors();
 
     /**
-     * return null or the identifier who match the correct identity
+     * Return null or the identifier who match the correct identity.
      * @return \Authentication\Identifier\IdentifierInterface|null
      */
     public function getIdentifier();
 
     /**
-     * set the identifier who match the correct identity or null
-     * @param \Authentication\Identifier\IdentifierInterface|null $identifier The matching identifier
+     * Set the identifier who match the correct identity or null.
+     * @param \Authentication\Identifier\IdentifierInterface|null $identifier The matching identifier.
      * @return void
      */
     public function setIdentifier(IdentifierInterface $identifier = null);
 
     /**
-     * return null or the authenticator who match the correct identity
+     * Return null or the authenticator who match the correct identity.
      * @return \Authentication\Authenticator\AuthenticatorInterface|null
      */
     public function getAuthenticator();
 
     /**
-     * set the authenticator who match the correct identity or null
-     * @param \Authentication\Authenticator\AuthenticatorInterface|null $authenticator The matching authenticator
+     * Set the authenticator who match the correct identity or null.
+     * @param \Authentication\Authenticator\AuthenticatorInterface|null $authenticator The matching authenticator.
      * @return void
      */
     public function setAuthenticator(AuthenticatorInterface $authenticator = null);

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -56,7 +56,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
         $user = $session->read($sessionKey);
 
         if (empty($user)) {
-            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
+            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, [], null, $this);
         }
 
         if ($this->getConfig('identify') === true) {
@@ -67,7 +67,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
             $user = $this->_identifier->identify($credentials);
 
             if (empty($user)) {
-                return new Result(null, Result::FAILURE_CREDENTIALS_INVALID);
+                return new Result(null, Result::FAILURE_CREDENTIALS_INVALID, [], $this->_identifier->getSuccessfulIdentifier(), $this);
             }
         }
 
@@ -75,7 +75,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
             $user = new ArrayObject($user);
         }
 
-        return new Result($user, Result::SUCCESS);
+        return new Result($user, Result::SUCCESS, [], $this->_identifier->getSuccessfulIdentifier(), $this);
     }
 
     /**

--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -118,7 +118,7 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
     {
         $token = $this->getToken($request);
         if ($token === null) {
-            return new Result(null, Result::FAILURE_CREDENTIALS_MISSING);
+            return new Result(null, Result::FAILURE_CREDENTIALS_MISSING, [], null, $this);
         }
 
         $user = $this->_identifier->identify([
@@ -126,10 +126,10 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
         ]);
 
         if (empty($user)) {
-            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
+            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors(), $this->_identifier->getSuccessfulIdentifier(), $this);
         }
 
-        return new Result($user, Result::SUCCESS);
+        return new Result($user, Result::SUCCESS, [], $this->_identifier->getSuccessfulIdentifier(), $this);
     }
 
     /**

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -34,7 +34,6 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
      */
     protected $_successfulIdentifier = null;
 
-
     /**
      * Identifies an user or service by the passed credentials
      *

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -29,6 +29,13 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
     protected $_errors = [];
 
     /**
+     * SuccessfulIdentifier
+     * @var null|Authentication\Identifier\IdentifierInterface
+     */
+    protected $_successfulIdentifier = null;
+
+
+    /**
      * Identifies an user or service by the passed credentials
      *
      * @param array $credentials Authentication credentials
@@ -40,10 +47,14 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
         foreach ($this->_loaded as $name => $identifier) {
             $result = $identifier->identify($credentials);
             if ($result) {
+                $this->setSuccessfulIdentifier($identifier);
+
                 return $result;
             }
             $this->_errors[$name] = $identifier->getErrors();
         }
+
+        $this->setSuccessfulIdentifier(null);
 
         return null;
     }
@@ -105,5 +116,24 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
     {
         $message = sprintf('Identifier class `%s` was not found.', $class);
         throw new RuntimeException($message);
+    }
+
+    /**
+     * set the identifier who found the identity
+     * @param IdentifierInterface|null $identifier successful identifier or null to unset
+     * @return void
+     */
+    public function setSuccessfulIdentifier(IdentifierInterface $identifier = null)
+    {
+        $this->_successfulIdentifier = $identifier;
+    }
+
+    /**
+     * get the successful identifier
+     * @return null|Authentication\Identifier\IdentifierInterface
+     */
+    public function getSuccessfulIdentifier()
+    {
+        return $this->_successfulIdentifier;
     }
 }

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -119,7 +119,7 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
 
     /**
      * set the identifier who found the identity
-     * @param IdentifierInterface|null $identifier successful identifier or null to unset
+     * @param \Authentication\Identifier\IdentifierInterface|null $identifier successful identifier or null to unset
      * @return void
      */
     public function setSuccessfulIdentifier(IdentifierInterface $identifier = null)
@@ -129,7 +129,7 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
 
     /**
      * get the successful identifier
-     * @return null|Authentication\Identifier\IdentifierInterface
+     * @return \Authentication\Identifier\IdentifierInterface|null
      */
     public function getSuccessfulIdentifier()
     {

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -30,7 +30,7 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
 
     /**
      * SuccessfulIdentifier
-     * @var null|Authentication\Identifier\IdentifierInterface
+     * @var \Authentication\Identifier\IdentifierInterface|null
      */
     protected $_successfulIdentifier = null;
 

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -29,7 +29,7 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
     protected $_errors = [];
 
     /**
-     * SuccessfulIdentifier
+     * The successful matching identifier.
      * @var \Authentication\Identifier\IdentifierInterface|null
      */
     protected $_successfulIdentifier = null;
@@ -118,8 +118,8 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
     }
 
     /**
-     * set the identifier who found the identity
-     * @param \Authentication\Identifier\IdentifierInterface|null $identifier successful identifier or null to unset
+     * Set the identifier who found the identity.
+     * @param \Authentication\Identifier\IdentifierInterface|null $identifier Successful identifier or null to unset.
      * @return void
      */
     public function setSuccessfulIdentifier(IdentifierInterface $identifier = null)
@@ -128,7 +128,7 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
     }
 
     /**
-     * get the successful identifier
+     * Get the successful identifier.
      * @return \Authentication\Identifier\IdentifierInterface|null
      */
     public function getSuccessfulIdentifier()

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -17,6 +17,7 @@ use ArrayObject;
 use Authentication\Authenticator\CookieAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
+use Authentication\Identifier\PasswordIdentifier;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -73,6 +74,8 @@ class CookieAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**
@@ -101,6 +104,8 @@ class CookieAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**
@@ -157,6 +162,8 @@ class CookieAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**
@@ -180,6 +187,8 @@ class CookieAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**
@@ -208,6 +217,8 @@ class CookieAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -17,6 +17,7 @@ namespace Authentication\Test\TestCase\Authenticator;
 use Authentication\Authenticator\FormAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
+use Authentication\Identifier\PasswordIdentifier;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -58,6 +59,8 @@ class FormAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+        $this->assertSame($form, $result->getAuthenticator());
     }
 
     /**
@@ -85,6 +88,8 @@ class FormAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
         $this->assertEquals([0 => 'Login credentials not found'], $result->getErrors());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($form, $result->getAuthenticator());
     }
 
     /**
@@ -112,6 +117,8 @@ class FormAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
         $this->assertEquals([0 => 'Login credentials not found'], $result->getErrors());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($form, $result->getAuthenticator());
     }
 
     /**
@@ -141,6 +148,8 @@ class FormAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_OTHER, $result->getStatus());
         $this->assertEquals([0 => 'Login URL `http://localhost/users/does-not-match` did not match `/users/login`.'], $result->getErrors());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($form, $result->getAuthenticator());
     }
 
     /**

--- a/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
@@ -17,6 +17,7 @@ namespace Authentication\Test\TestCase\Authenticator;
 use Authentication\Authenticator\HttpBasicAuthenticator;
 use Authentication\Authenticator\UnauthorizedException;
 use Authentication\Identifier\IdentifierCollection;
+use Authentication\Identifier\PasswordIdentifier;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -85,6 +86,8 @@ class HttpBasicAuthenticatorTest extends TestCase
 
         $result = $this->auth->authenticate($request, $this->response);
         $this->assertFalse($result->isValid());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($this->auth, $result->getAuthenticator());
     }
 
     /**
@@ -228,5 +231,7 @@ class HttpBasicAuthenticatorTest extends TestCase
 
         $this->assertTrue($result->isValid());
         $this->assertArraySubset($expected, $result->getData()->toArray());
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+        $this->assertSame($this->auth, $result->getAuthenticator());
     }
 }

--- a/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
@@ -20,6 +20,7 @@ use Authentication\Authenticator\Result;
 use Authentication\Authenticator\StatelessInterface;
 use Authentication\Authenticator\UnauthorizedException;
 use Authentication\Identifier\IdentifierCollection;
+use Authentication\Identifier\PasswordIdentifier;
 use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -105,6 +106,8 @@ class HttpDigestAuthenticatorTest extends TestCase
         $result = $this->auth->authenticate($request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isValid());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($this->auth, $result->getAuthenticator());
     }
 
     /**
@@ -135,6 +138,8 @@ DIGEST;
 
         $result = $this->auth->authenticate($request, $this->response);
         $this->assertFalse($result->isValid(), 'Should fail');
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($this->auth, $result->getAuthenticator());
     }
 
     /**
@@ -173,6 +178,8 @@ DIGEST;
         $this->assertInstanceOf(Result::class, $result);
         $this->assertTrue($result->isValid());
         $this->assertArraySubset($expected, $result->getData()->toArray());
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+        $this->assertSame($this->auth, $result->getAuthenticator());
     }
 
     /**
@@ -204,6 +211,8 @@ DIGEST;
         $result = $this->auth->authenticate($request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isValid());
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+        $this->assertSame($this->auth, $result->getAuthenticator());
     }
 
     /**
@@ -235,6 +244,8 @@ DIGEST;
         $result = $this->auth->authenticate($request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isValid());
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+        $this->assertSame($this->auth, $result->getAuthenticator());
     }
 
     /**
@@ -262,6 +273,8 @@ DIGEST;
         $result = $this->auth->authenticate($request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isValid());
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+        $this->assertSame($this->auth, $result->getAuthenticator());
     }
 
     /**

--- a/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
@@ -19,6 +19,7 @@ use ArrayObject;
 use Authentication\Authenticator\JwtAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
+use Authentication\Identifier\PasswordIdentifier;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -91,6 +92,8 @@ class JwtAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::SUCCESS, $result->getStatus());
         $this->assertInstanceOf(ArrayAccess::class, $result->getData());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**
@@ -113,6 +116,8 @@ class JwtAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::SUCCESS, $result->getStatus());
         $this->assertInstanceOf(ArrayAccess::class, $result->getData());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**
@@ -184,6 +189,8 @@ class JwtAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
         $this->assertNull($result->getData());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**
@@ -217,6 +224,8 @@ class JwtAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
         $this->assertNUll($result->getData());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     public function testInvalidToken()
@@ -233,6 +242,8 @@ class JwtAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($this->request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
         $this->assertNUll($result->getData());
         $errors = $result->getErrors();
         $this->assertArrayHasKey('message', $errors);

--- a/tests/TestCase/Authenticator/ResultTest.php
+++ b/tests/TestCase/Authenticator/ResultTest.php
@@ -15,6 +15,7 @@
 namespace Authentication\Test\TestCase\Authenticator;
 
 use Authentication\Authenticator\Result;
+use Authentication\Identifier\PasswordIdentifier;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
@@ -124,5 +125,21 @@ class ResultTest extends TestCase
         $entity = new Entity(['user' => 'florian']);
         $result = new Result($entity, Result::FAILURE_OTHER, $messages);
         $this->assertEquals($messages, $result->getErrors());
+    }
+
+    /**
+     * testGetErrors
+     *
+     * @return void
+     */
+    public function testSetIdentifier()
+    {
+        $result = new Result(['user' => 'florian'], Result::SUCCESS);
+        $identifier = new PasswordIdentifier;
+        $result->setIdentifier($identifier);
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+
+        $result->setIdentifier(null);
+        $this->assertNull($result->getIdentifier());
     }
 }

--- a/tests/TestCase/Authenticator/ResultTest.php
+++ b/tests/TestCase/Authenticator/ResultTest.php
@@ -25,7 +25,6 @@ use stdClass;
 
 class ResultTest extends TestCase
 {
-
     /**
      * testConstructorEmptyData
      *
@@ -48,6 +47,25 @@ class ResultTest extends TestCase
     public function testConstructorInvalidData()
     {
         new Result(new stdClass, Result::FAILURE_CREDENTIALS_INVALID);
+    }
+
+    /**
+     * testConstructorIdentifierAndAuthenticator
+     *
+     * @return void
+     */
+    public function testConstructorIdentifierAndAuthenticator()
+    {
+        $identifiers = new IdentifierCollection([
+           'Authentication.Password'
+        ]);
+        $authenticator = new FormAuthenticator($identifiers);
+        $identifier = new PasswordIdentifier;
+
+        $result = new Result(['user' => 'florian'], Result::SUCCESS, [], $identifier, $authenticator);
+
+        $this->assertSame($identifier, $result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**

--- a/tests/TestCase/Authenticator/ResultTest.php
+++ b/tests/TestCase/Authenticator/ResultTest.php
@@ -14,7 +14,9 @@
  */
 namespace Authentication\Test\TestCase\Authenticator;
 
+use Authentication\Authenticator\FormAuthenticator;
 use Authentication\Authenticator\Result;
+use Authentication\Identifier\IdentifierCollection;
 use Authentication\Identifier\PasswordIdentifier;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
@@ -128,7 +130,7 @@ class ResultTest extends TestCase
     }
 
     /**
-     * testGetErrors
+     * testSetIdentifier
      *
      * @return void
      */
@@ -141,5 +143,27 @@ class ResultTest extends TestCase
 
         $result->setIdentifier(null);
         $this->assertNull($result->getIdentifier());
+    }
+
+    /**
+     * testSetAuthenticator
+     *
+     * @return void
+     */
+    public function testSetAuthenticator()
+    {
+        $identifiers = new IdentifierCollection([
+           'Authentication.Password'
+        ]);
+
+        $result = new Result(['user' => 'florian'], Result::SUCCESS);
+
+        $authenticator = new FormAuthenticator($identifiers);
+
+        $result->setAuthenticator($authenticator);
+        $this->assertInstanceOf(FormAuthenticator::class, $result->getAuthenticator());
+
+        $result->setAuthenticator(null);
+        $this->assertNull($result->getAuthenticator());
     }
 }

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -18,6 +18,7 @@ use ArrayObject;
 use Authentication\Authenticator\Result;
 use Authentication\Authenticator\SessionAuthenticator;
 use Authentication\Identifier\IdentifierCollection;
+use Authentication\Identifier\PasswordIdentifier;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -83,6 +84,8 @@ class SessionAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
 
         $this->sessionMock->expects($this->at(0))
             ->method('read')
@@ -96,6 +99,8 @@ class SessionAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**
@@ -125,6 +130,8 @@ class SessionAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertInstanceOf(PasswordIdentifier::class, $result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
 
         $this->sessionMock->expects($this->at(0))
             ->method('read')
@@ -143,6 +150,8 @@ class SessionAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($authenticator, $result->getAuthenticator());
     }
 
     /**

--- a/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
@@ -17,6 +17,7 @@ namespace Authentication\Test\TestCase\Authenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Authenticator\TokenAuthenticator;
 use Authentication\Identifier\IdentifierCollection;
+use Authentication\Identifier\TokenIdentifier;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -70,6 +71,8 @@ class TokenAuthenticatorTest extends TestCase
         $result = $tokenAuth->authenticate($this->request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($tokenAuth, $result->getAuthenticator());
 
         // Test header token
         $requestWithHeaders = $this->request->withAddedHeader('Token', 'mariano');
@@ -79,6 +82,8 @@ class TokenAuthenticatorTest extends TestCase
         $result = $tokenAuth->authenticate($requestWithHeaders, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertInstanceOf(TokenIdentifier::class, $result->getIdentifier());
+        $this->assertSame($tokenAuth, $result->getAuthenticator());
     }
 
     /**
@@ -96,6 +101,8 @@ class TokenAuthenticatorTest extends TestCase
         $result = $tokenAuth->authenticate($requestWithParams, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertInstanceOf(TokenIdentifier::class, $result->getIdentifier());
+        $this->assertSame($tokenAuth, $result->getAuthenticator());
 
         // Test with valid query param but invalid token
         $requestWithParams = $this->request->withQueryParams(['token' => 'does-not-exist']);
@@ -105,6 +112,8 @@ class TokenAuthenticatorTest extends TestCase
         $result = $tokenAuth->authenticate($requestWithParams, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($tokenAuth, $result->getAuthenticator());
     }
 
     /**
@@ -123,6 +132,8 @@ class TokenAuthenticatorTest extends TestCase
         $result = $tokenAuth->authenticate($requestWithHeaders, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertInstanceOf(TokenIdentifier::class, $result->getIdentifier());
+        $this->assertSame($tokenAuth, $result->getAuthenticator());
 
         //invalid prefix
         $requestWithHeaders = $this->request->withAddedHeader('Token', 'bearer mariano');
@@ -133,5 +144,7 @@ class TokenAuthenticatorTest extends TestCase
         $result = $tokenAuth->authenticate($requestWithHeaders, $this->response);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertNull($result->getIdentifier());
+        $this->assertSame($tokenAuth, $result->getAuthenticator());
     }
 }

--- a/tests/TestCase/Identifier/IdentifierCollectionTest.php
+++ b/tests/TestCase/Identifier/IdentifierCollectionTest.php
@@ -16,6 +16,7 @@ namespace Authentication\Test\TestCase\Identifier;
 
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Identifier\IdentifierInterface;
+use Authentication\Identifier\PasswordIdentifier;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use TestApp\Authentication\Identifier\InvalidIdentifier;
 
@@ -121,5 +122,24 @@ class IdentifierCollectionTest extends TestCase
         ]);
 
         $this->assertInstanceOf('\ArrayAccess', $result);
+        $this->assertInstanceOf(PasswordIdentifier::class, $collection->getSuccessfulIdentifier());
+    }
+
+    /**
+     * testIdentify
+     *
+     * @return void
+     */
+    public function testSuccessfulIdentifier()
+    {
+        $collection = new IdentifierCollection();
+        $this->assertNull($collection->getSuccessfulIdentifier());
+
+        $identifier = new PasswordIdentifier;
+        $collection->setSuccessfulIdentifier($identifier);
+        $this->assertInstanceOf(PasswordIdentifier::class, $collection->getSuccessfulIdentifier());
+
+        $collection->setSuccessfulIdentifier(null);
+        $this->assertNull($collection->getSuccessfulIdentifier());
     }
 }

--- a/tests/TestCase/Identifier/IdentifierCollectionTest.php
+++ b/tests/TestCase/Identifier/IdentifierCollectionTest.php
@@ -126,7 +126,7 @@ class IdentifierCollectionTest extends TestCase
     }
 
     /**
-     * testIdentify
+     * testSuccessfulIdentifier
      *
      * @return void
      */


### PR DESCRIPTION
attache Identifier and Authenticator to result.

This allow more control in Controller when there is multiple authenticators and should do actions when a specific authentication or identifier match.

Refs https://github.com/cakephp/authentication/issues/283