### PR TITLE
unauthenticatedRedirect Spelling correction

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -333,7 +333,7 @@ class AuthenticationService implements AuthenticationServiceInterface
     /**
      * Return the URL to redirect unauthenticated users to.
      *
-     * If the `unauthenticaedRedirect` option is not set,
+     * If the `unauthenticatedRedirect` option is not set,
      * this method will return null.
      *
      * If the `queryParam` option is set a query parameter


### PR DESCRIPTION
Previous spelling for "unauthenticatedRedirect" was written in comment as "unauthenticaedRedirect".