### PR TITLE
Strict check around auth topic.

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -137,7 +137,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
 
         $request = $this->getController()->request;
         $action = $request->getParam('action');
-        if (in_array($action, $this->unauthenticatedActions)) {
+        if (in_array($action, $this->unauthenticatedActions, true)) {
             return;
         }
 


### PR DESCRIPTION
We shouldnt use fuzzy matching in auth scope.
Best to use strict comparison here.