### PR TITLE
Docblock update in AuthenticationMiddleware.php

### DIFF
--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -57,7 +57,7 @@ class AuthenticationMiddleware
     /**
      * Constructor
      *
-     * @param \Authentication\AuthenticationServiceInterface|\Authentication\AuthenticationServiceProviderInterface $subject Authentication service or application instance.
+     * @param \Cake\Http\BaseApplication|\Authentication\AuthenticationServiceInterface|\Authentication\AuthenticationServiceProviderInterface $subject Authentication service or application instance.
      * @param array $config Array of configuration settings.
      * @throws \InvalidArgumentException When invalid subject has been passed.
      */


### PR DESCRIPTION
Added `BaseApplication` as possible `$subject` type based on this:

"`$subject` Authentication service or application instance."

And the docs: https://book.cakephp.org/authentication/1.1/en/#getting-started

`$authentication = new AuthenticationMiddleware($this);`