### PR TITLE
OrmResolver: allow fetching associations via config key 'contain'

### DIFF
--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -169,6 +169,7 @@ Configuration options:
 -  **userModel**: The user model identities are located in. Default is
    ``Users``.
 -  **finder**: The finder to use with the model. Default is ``all``.
+-  **contain**: array of contained associations. Default is ``[]``.
 
 In order to use ORM resolver you must require ``cakephp/orm`` in your
 ``composer.json`` file.

--- a/src/Identifier/Resolver/OrmResolver.php
+++ b/src/Identifier/Resolver/OrmResolver.php
@@ -36,6 +36,7 @@ class OrmResolver implements ResolverInterface
     protected $_defaultConfig = [
         'userModel' => 'Users',
         'finder' => 'all',
+        'contain' => []
     ];
 
     /**
@@ -74,6 +75,6 @@ class OrmResolver implements ResolverInterface
             $where[$field] = $value;
         }
 
-        return $query->where([$type => $where])->first();
+        return $query->where([$type => $where])->contain((array)$this->_config['contain'])->first();
     }
 }


### PR DESCRIPTION
Re-querying the user record with associations after successful authentication seemed ineffective to me, hence this little update to default OrmResolver, so it could fetch the associations directly when authenticating and then the resulting entity with contained associations would be available in (basic example) session Auth.