### PR TITLE
Fix overwriting identity data.

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -397,8 +397,7 @@ class AuthenticationService implements AuthenticationServiceInterface
     {
         $redirectParam = $this->getConfig('queryParam');
         $params = $request->getQueryParams();
-        if (
-            empty($redirectParam) ||
+        if (empty($redirectParam) ||
             !isset($params[$redirectParam]) ||
             strlen($params[$redirectParam]) === 0
         ) {

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -397,7 +397,8 @@ class AuthenticationService implements AuthenticationServiceInterface
     {
         $redirectParam = $this->getConfig('queryParam');
         $params = $request->getQueryParams();
-        if (empty($redirectParam) ||
+        if (
+            empty($redirectParam) ||
             !isset($params[$redirectParam]) ||
             strlen($params[$redirectParam]) === 0
         ) {

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -30,7 +30,6 @@ use RuntimeException;
  */
 class CookieAuthenticator extends AbstractAuthenticator implements PersistenceInterface
 {
-
     use PasswordHasherTrait;
     use UrlCheckerTrait;
 

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -26,7 +26,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class FormAuthenticator extends AbstractAuthenticator
 {
-
     use UrlCheckerTrait;
 
     /**

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -235,7 +235,12 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     }
 
     /**
-     * Set identity data to all authenticators that are loaded and support persistence.
+     * Replace the current identity
+     *
+     * Clear and replace identity data in all authenticators
+     * that are loaded and support persistence. The identity
+     * is cleared and then set to ensure that privilege escalation
+     * and de-escalation include side effects like session rotation.
      *
      * @param \ArrayAccess $identity Identity data to persist.
      * @return $this
@@ -243,10 +248,15 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     public function setIdentity(ArrayAccess $identity)
     {
         $controller = $this->getController();
+        $service = $this->getAuthenticationService();
 
-        $result = $this->getAuthenticationService()->persistIdentity(
+        $result = $service->clearIdentity(
             $controller->request,
-            $controller->response,
+            $controller->response
+        );
+        $result = $service->persistIdentity(
+            $result['request'],
+            $result['response'],
             $identity
         );
 

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -87,7 +87,8 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
         $authentication = $this->getAuthenticationService();
         $provider = $authentication->getAuthenticationProvider();
 
-        if ($provider === null ||
+        if (
+            $provider === null ||
             $provider instanceof PersistenceInterface ||
             $provider instanceof StatelessInterface
         ) {

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -87,8 +87,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
         $authentication = $this->getAuthenticationService();
         $provider = $authentication->getAuthenticationProvider();
 
-        if (
-            $provider === null ||
+        if ($provider === null ||
             $provider instanceof PersistenceInterface ||
             $provider instanceof StatelessInterface
         ) {

--- a/src/Identifier/AbstractIdentifier.php
+++ b/src/Identifier/AbstractIdentifier.php
@@ -18,7 +18,6 @@ use Cake\Core\InstanceConfigTrait;
 
 abstract class AbstractIdentifier implements IdentifierInterface
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/src/Identifier/PasswordIdentifier.php
+++ b/src/Identifier/PasswordIdentifier.php
@@ -38,7 +38,6 @@ use Authentication\PasswordHasher\PasswordHasherTrait;
  */
 class PasswordIdentifier extends AbstractIdentifier
 {
-
     use PasswordHasherTrait {
         getPasswordHasher as protected _getPasswordHasher;
     }

--- a/src/Identifier/Resolver/OrmResolver.php
+++ b/src/Identifier/Resolver/OrmResolver.php
@@ -19,7 +19,6 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 
 class OrmResolver implements ResolverInterface
 {
-
     use InstanceConfigTrait;
     use LocatorAwareTrait;
 

--- a/src/Identifier/TokenIdentifier.php
+++ b/src/Identifier/TokenIdentifier.php
@@ -21,7 +21,6 @@ use Authentication\Identifier\Resolver\ResolverAwareTrait;
  */
 class TokenIdentifier extends AbstractIdentifier
 {
-
     use ResolverAwareTrait;
 
     /**

--- a/src/PasswordHasher/AbstractPasswordHasher.php
+++ b/src/PasswordHasher/AbstractPasswordHasher.php
@@ -20,7 +20,6 @@ use Cake\Core\InstanceConfigTrait;
  */
 abstract class AbstractPasswordHasher implements PasswordHasherInterface
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/tests/TestCase/Authenticator/ResultTest.php
+++ b/tests/TestCase/Authenticator/ResultTest.php
@@ -44,7 +44,7 @@ class ResultTest extends TestCase
      */
     public function testConstructorInvalidData()
     {
-        new Result(new stdClass, Result::FAILURE_CREDENTIALS_INVALID);
+        new Result(new stdClass(), Result::FAILURE_CREDENTIALS_INVALID);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -159,7 +159,7 @@ class AuthenticationComponentTest extends TestCase
     }
 
     /**
-     * testGetIdentity
+     * testSetIdentity
      *
      * @eturn void
      */
@@ -174,6 +174,41 @@ class AuthenticationComponentTest extends TestCase
         $component->setIdentity($this->identityData);
         $result = $component->getIdentity();
         $this->assertSame($this->identityData, $result->getOriginalData());
+    }
+
+    /**
+     * Ensure setIdentity() clears identity and persists identity data.
+     *
+     * @eturn void
+     */
+    public function testSetIdentityOverwrite()
+    {
+        $request = $this->request->withAttribute('authentication', $this->service);
+
+        $controller = new Controller($request, $this->response);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $component->setIdentity($this->identityData);
+        $result = $component->getIdentity();
+        $this->assertSame($this->identityData, $result->getOriginalData());
+        $this->assertSame(
+            $this->identityData->username,
+            $request->getSession()->read('Auth.username'),
+            'Session should be updated.'
+        );
+
+        // Replace the identity
+        $newIdentity = new Entity(['username' => 'jessie']);
+        $component->setIdentity($newIdentity);
+
+        $result = $component->getIdentity();
+        $this->assertSame($newIdentity, $result->getOriginalData());
+        $this->assertSame(
+            $newIdentity->username,
+            $request->getSession()->read('Auth.username'),
+            'Session should be updated.'
+        );
     }
 
     /**

--- a/tests/TestCase/Identifier/LdapIdentifierTest.php
+++ b/tests/TestCase/Identifier/LdapIdentifierTest.php
@@ -121,7 +121,7 @@ class LdapIdentifierTest extends TestCase
      */
     public function testWrongLdapObject()
     {
-        $notLdap = new stdClass;
+        $notLdap = new stdClass();
 
         $identifier = new LdapIdentifier([
             'host' => 'ldap.example.com',

--- a/tests/TestCase/IdentityTest.php
+++ b/tests/TestCase/IdentityTest.php
@@ -122,7 +122,7 @@ class IdentityTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('data must be an `array` or implement `ArrayAccess` interface, `stdClass` given.');
-        new Identity(new \stdClass);
+        new Identity(new \stdClass());
     }
 
     /**


### PR DESCRIPTION
Replace the logged in user with another. By clearing the identity and then setting the new one we ensure that session ids are rotated when simulating logins which is outlined in the owasp session cheatsheet[1].

Fixes #320

[1] https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#renew-the-session-id-after-any-privilege-level-change