### PR TITLE
Update documentation link to point to correct URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,4 +38,4 @@ public function bootstrap(): void
 ## Documentation
 
 Documentation for this plugin can be found in the [CakePHP
-Cookbook](https://book.cakephp.org/authentication/2.0/en/)
+Cookbook](https://book.cakephp.org/authentication/2/en/)


### PR DESCRIPTION
The URL was pointing to a 404 page, caused due to incorrect URL in the documentation.
Updated the URL to use `2.x` or `2` rather than `2.0`.