### PR TITLE
fix a typo

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -93,7 +93,7 @@ class AuthenticationService implements AuthenticationServiceInterface
         'identityClass' => Identity::class,
         'identityAttribute' => 'identity',
         'queryParam' => null,
-        'unauthorizedRedirect' => null,
+        'unauthenticatedRedirect' => null,
     ];
 
     /**


### PR DESCRIPTION
I was reviewing the code and I found this and so I did not test on local :) 

Refs dd5ba91
according to above commit , it was `unauthenticatedRedirect` before but now is `unauthorizedRedirect` !!

@markstory can you confirm this? 

this is alternative to #325 that was mistaken opened on branch 2.x 