### PR TITLE
Show URL base in login URL mismatch error message.

### DIFF
--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -81,10 +81,15 @@ class FormAuthenticator extends AbstractAuthenticator
      */
     protected function _buildLoginUrlErrorResult($request)
     {
+        $uri = $request->getUri();
+        if (property_exists($uri, 'base')) {
+            $uri = $uri->withPath($uri->base . $uri->getPath());
+        }
+
         $errors = [
             sprintf(
                 'Login URL `%s` did not match `%s`.',
-                (string)$request->getUri(),
+                (string)$uri,
                 implode('` or `', (array)$this->getConfig('loginUrl'))
             ),
         ];

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -82,8 +82,9 @@ class FormAuthenticator extends AbstractAuthenticator
     protected function _buildLoginUrlErrorResult($request)
     {
         $uri = $request->getUri();
-        if (property_exists($uri, 'base')) {
-            $uri = $uri->withPath($uri->base . $uri->getPath());
+        $base = $request->getAttribute('base');
+        if ($base !== null) {
+            $uri = $uri->withPath((string)$base . $uri->getPath());
         }
 
         $errors = [

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -194,6 +194,7 @@ class FormAuthenticatorTest extends TestCase
         $uri = $request->getUri();
         $uri->base = '/base';
         $request = $request->withUri($uri);
+        $request = $request->withAttribute('base', $uri->base);
         $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
@@ -287,6 +288,7 @@ class FormAuthenticatorTest extends TestCase
         $uri = $request->getUri();
         $uri->base = '/base';
         $request = $request->withUri($uri);
+        $request = $request->withAttribute('base', $uri->base);
         $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -176,6 +176,38 @@ class FormAuthenticatorTest extends TestCase
     }
 
     /**
+     * testLoginUrlMismatchWithBase
+     *
+     * @return void
+     */
+    public function testLoginUrlMismatchWithBase()
+    {
+        $identifiers = new IdentifierCollection([
+            'Authentication.Password',
+        ]);
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/users/login'],
+            [],
+            ['username' => 'mariano', 'password' => 'password']
+        );
+        $uri = $request->getUri();
+        $uri->base = '/base';
+        $request = $request->withUri($uri);
+        $response = new Response();
+
+        $form = new FormAuthenticator($identifiers, [
+            'loginUrl' => '/users/login',
+        ]);
+
+        $result = $form->authenticate($request, $response);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertEquals(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertEquals([0 => 'Login URL `http://localhost/base/users/login` did not match `/users/login`.'], $result->getErrors());
+    }
+
+    /**
      * testSingleLoginUrlSuccess
      *
      * @return void
@@ -227,6 +259,38 @@ class FormAuthenticatorTest extends TestCase
                 '/en/users/login',
                 '/de/users/login',
             ],
+        ]);
+
+        $result = $form->authenticate($request, $response);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertEquals([], $result->getErrors());
+    }
+
+    /**
+     * testLoginUrlSuccessWithBase
+     *
+     * @return void
+     */
+    public function testLoginUrlSuccessWithBase()
+    {
+        $identifiers = new IdentifierCollection([
+            'Authentication.Password',
+        ]);
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/users/login'],
+            [],
+            ['username' => 'mariano', 'password' => 'password']
+        );
+        $uri = $request->getUri();
+        $uri->base = '/base';
+        $request = $request->withUri($uri);
+        $response = new Response();
+
+        $form = new FormAuthenticator($identifiers, [
+            'loginUrl' => '/base/users/login',
         ]);
 
         $result = $form->authenticate($request, $response);


### PR DESCRIPTION
With the base missing, error messages like `http:://localhost/users/login did not match /users/login` would be produced, which cloaks the actual issue of the missing base in the configured login URL.

Ideally the error message would only show the full URL in case the assigned URL checker actually tests against a full URL, but the URL checker interface doesn't really allow that.