### PR TITLE
Explain how data is passed from TokenAuth to identifier

### DIFF
--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -79,6 +79,12 @@ An example of getting a token from a header, or query string would be::
 The above would read the ``token`` GET parameter or the ``Authorization`` header
 as long as the token was preceded by ``Token`` and a space.
 
+The token will always be passed to the configured identifier as follows::
+
+    [
+        'token' => '{token-value}',
+    ]
+
 JWT
 ===
 


### PR DESCRIPTION
I needed to change the query name of the token and thought I also change the name of the field in the identifier.

Before:

```` php
        $service->loadIdentifier('Authentication.Token', [
            'tokenField' => 'token',
            'dataField' => 'token',
        ]);

        $service->loadAuthenticator('Authentication.Token', [
            'queryParam' => 'token',
        ]);
````

After:

```` php
        $service->loadIdentifier('Authentication.Token', [
            'tokenField' => 'partner_code',
            'dataField' => 'partner_code',
        ]);

        $service->loadAuthenticator('Authentication.Token', [
            'queryParam' => 'partner_code',
        ]);
````

But that didn't work.

Through debugging, I found out, the token value is passed with a ``token`` key, regardless of what I have configured for my Authenticator.

https://github.com/cakephp/authentication/blob/1.4.1/src/Authenticator/TokenAuthenticator.php#L125

This works:

```` php
        $service->loadIdentifier('Authentication.Token', [
            'tokenField' => 'partner_code',
            'dataField' => 'token',
        ]);

        $service->loadAuthenticator('Authentication.Token', [
            'queryParam' => 'partner_code',
        ]);
````

To prevent further confusion, I added some explanation.

This should be done for other Authenticators, too, by the way.