### PR TITLE
Quick start guide improvements

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -132,7 +132,18 @@ like::
         }
     }
 
-Then add a simple logout action::
+Make sure that you whitelist the ``login`` action in your controller's
+``beforeFilter()`` callback as mentioned in the previous section, so that
+unauthenticated users are able to access it::
+
+    public function beforeFilter(\Cake\Event\EventInterface $event)
+    {
+        parent::beforeFilter($event);
+
+        $this->Authentication->allowUnauthenticated(['login']);
+    }
+
+and then add a simple logout action::
 
     public function logout()
     {

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -45,6 +45,10 @@ Example of configuring the authentication middleware using ``authentication`` ap
         public function getAuthenticationService(ServerRequestInterface $request): AuthenticationServiceInterface
         {
             $service = new AuthenticationService();
+            $service->setConfig([
+                'unauthenticatedRedirect' => '/users/login',
+                'queryParam' => 'redirect',
+            ]);
 
             $fields = [
                 'username' => 'email',


### PR DESCRIPTION
The `queryParam` option is somewhat required, given that the login action example tries to obtain it, and just like the `unauthenticatedRedirect` option it is only mentioned in the migration guide, which new users probably won't look up.

A concrete example of whitelisting specifically the `login` action should help new/inexperienced users, without the action allowed the example won't work.