### PR TITLE
Avoid unnecessary file operations.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,8 +18,28 @@ namespace Authentication;
 use Cake\Core\BasePlugin;
 
 /**
- * Plugin class for CakePHP 3.6.0 plugin collection.
+ * Plugin class for CakePHP.
  */
 class Plugin extends BasePlugin
 {
+    /**
+     * Do bootstrapping or not
+     *
+     * @var bool
+     */
+    protected $bootstrapEnabled = false;
+
+    /**
+     * Load routes or not
+     *
+     * @var bool
+     */
+    protected $routesEnabled = false;
+
+    /**
+     * Console middleware
+     *
+     * @var bool
+     */
+    protected $consoleEnabled = false;    
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,5 +41,5 @@ class Plugin extends BasePlugin
      *
      * @var bool
      */
-    protected $consoleEnabled = false;    
+    protected $consoleEnabled = false;
 }


### PR DESCRIPTION
This plugin doesn't have bootstrap file or routes file or console commands.