### PR TITLE
Alternative redirect URL schema

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -363,9 +363,6 @@ class AuthenticationService implements AuthenticationServiceInterface
         }
 
         $uri = $request->getUri();
-        if (property_exists($uri, 'base')) {
-            $uri = $uri->withPath($uri->base . $uri->getPath());
-        }
         $redirect = $uri->getPath();
         if ($uri->getQuery()) {
             $redirect .= '?' . $uri->getQuery();


### PR DESCRIPTION
The easiest way to write a login action is using the example in the [documentation](https://book.cakephp.org/authentication/2/en/index.html#building-a-login-action)
```
public function login()
{
    $result = $this->Authentication->getResult();
    // If the user is logged in send them away.
    if ($result->isValid()) {
        $target = $this->Authentication->getLoginRedirect() ?? '/home';
        return $this->redirect($target);
    }
    if ($this->request->is('post') && !$result->isValid()) {
        $this->Flash->error('Invalid username or password');
    }
}
```

`$this->redirect()` actually does not respect a preceding slash the same way that a URL anchor would. As it stands, if an application is hosted at example.com/app/, and you browse unauthenticated to `example.com/app/private/area`:
* `AuthenticationService::getUnauthenticatedRedirectUrl()` would return `/app/private/area`
* This would cause a redirect to `/users/login?redirect=%2Fapp%2Fprivate%2Farea`
* Once authenticated, `getLoginRedirect` would return `/app/private/area`
* `$this->redirect('/app/private/area')` will cause a redirect to a 404 page at `example.com/app/app/private/area`.

We need to either suggest an alternative way to redirect in the example login action or change how `$this->Authentication->getUnauthenticatedRedirectUrl` generates the URL - for example how this pull request does it.