### PR TITLE
Prevent pass unset queryParam to getTokenFromQuery

### DIFF
--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -91,10 +91,10 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
      * Gets the token from the request headers
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
-     * @param string $queryParam Request query parameter name
+     * @param string|null $queryParam Request query parameter name
      * @return string|null
      */
-    protected function getTokenFromQuery(ServerRequestInterface $request, string $queryParam): ?string
+    protected function getTokenFromQuery(ServerRequestInterface $request, ?string $queryParam): ?string
     {
         $queryParams = $request->getQueryParams();
 


### PR DESCRIPTION
Following the Token Authenticator documentation, queryParam is optional.
Add an optional param to getTokenFromQuery to avoid the code crashes when
queryParam is unset.

From documentation:

> "...
> queryParam: Name of the query parameter. Configure it if you want to get the token from the query parameters.
> header: Name of the header. Configure it if you want to get the token from the header.
> "