### PR TITLE
Handle missing param config

### DIFF
--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -88,21 +88,22 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
     }
 
     /**
-     * Gets the token from the request headers
+     * Gets the token from the request query
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
      * @param string $queryParam Request query parameter name
      * @return string|null
      */
-    protected function getTokenFromQuery(ServerRequestInterface $request, string $queryParam): ?string
+    protected function getTokenFromQuery(ServerRequestInterface $request, ?string $queryParam): ?string
     {
-        $queryParams = $request->getQueryParams();
-
-        if (empty($queryParams[$queryParam])) {
-            return null;
+        if (!empty($queryParam)) {
+            $queryParams = $request->getQueryParams();
+            if (!empty($queryParams[$queryParam])) {
+                return $queryParams[$queryParam];
+            }
         }
 
-        return $queryParams[$queryParam];
+        return null;
     }
 
     /**

--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -96,14 +96,13 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
      */
     protected function getTokenFromQuery(ServerRequestInterface $request, ?string $queryParam): ?string
     {
-        if (!empty($queryParam)) {
-            $queryParams = $request->getQueryParams();
-            if (!empty($queryParams[$queryParam])) {
-                return $queryParams[$queryParam];
-            }
+        if (empty($queryParam)) {
+            return null;
         }
 
-        return null;
+        $queryParams = $request->getQueryParams();
+
+        return $queryParams[$queryParam] ?? null;
     }
 
     /**

--- a/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
@@ -135,4 +135,50 @@ class TokenAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
     }
+
+    /**
+     * testWithoutQueryParamConfig
+     *
+     * @return void
+     */
+    public function testWithoutQueryParamConfig()
+    {
+        $tokenAuth = new TokenAuthenticator($this->identifiers, [
+            'header' => 'Token',
+        ]);
+
+        $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals(), $this->response);
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+    }
+
+    /**
+     * testWithoutHeaderConfig
+     *
+     * @return void
+     */
+    public function testWithoutHeaderConfig()
+    {
+        $tokenAuth = new TokenAuthenticator($this->identifiers, [
+            'queryParam' => 'token',
+        ]);
+
+        $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals(), $this->response);
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+    }
+
+    /**
+     * testWithoutAnyConfig
+     *
+     * @return void
+     */
+    public function testWithoutAnyConfig()
+    {
+        $tokenAuth = new TokenAuthenticator($this->identifiers);
+
+        $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals(), $this->response);
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+    }
 }


### PR DESCRIPTION
Replaces #349 
We can't assume that a user sets up a config value for using the queryParam.
