### PR TITLE
Feature - Legacy Password salt hash

### DIFF
--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -21,7 +21,8 @@ using the Password Identifier looks like::
                'Authentication.Default',
                [
                    'className' => 'Authentication.Legacy',
-                   'hashType' => 'md5'
+                   'hashType' => 'md5',
+                   'salt' => false
                ],
            ]
        ]

--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -21,8 +21,7 @@ using the Password Identifier looks like::
                'Authentication.Default',
                [
                    'className' => 'Authentication.Legacy',
-                   'hashType' => 'md5',
-                   'salt' => false
+                   'hashType' => 'md5'
                ],
            ]
        ]

--- a/docs/en/password-hashers.rst
+++ b/docs/en/password-hashers.rst
@@ -18,6 +18,9 @@ The config options for this adapter are:
    ``PASSWORD_DEFAULT``
 -  **hashOptions**: Associative array of options. Check the PHP manual
    for supported options for each hash type. Defaults to empty array.
+-  **salt**: Boolean flag for salting the password in a hashes, and checks. Useful
+    for legacy databases where passwords were stored with no salt, or environments which have
+    multiple apps saving passwords.
 
 Legacy
 ======

--- a/docs/en/password-hashers.rst
+++ b/docs/en/password-hashers.rst
@@ -18,9 +18,6 @@ The config options for this adapter are:
    ``PASSWORD_DEFAULT``
 -  **hashOptions**: Associative array of options. Check the PHP manual
    for supported options for each hash type. Defaults to empty array.
--  **salt**: Boolean flag for salting the password in a hashes, and checks. Useful
-    for legacy databases where passwords were stored with no salt, or environments which have
-    multiple apps saving passwords.
 
 Legacy
 ======
@@ -52,7 +49,8 @@ fallback hasher as follows::
                'Authentication.Default',
                [
                    'className' => 'Authentication.Legacy',
-                   'hashType' => 'md5'
+                   'hashType' => 'md5',
+                   'salt' => false // turn off default usage of salt
                ],
            ]
        ]

--- a/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/src/PasswordHasher/LegacyPasswordHasher.php
@@ -36,7 +36,7 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
      */
     protected $_defaultConfig = [
         'hashType' => null,
-        'salt' => null
+        'salt' => null,
     ];
 
     /**

--- a/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/src/PasswordHasher/LegacyPasswordHasher.php
@@ -30,7 +30,7 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
     /**
      * Default config for this object.
      * - `hashType` String identifier of the hash type to use on the password. (e.g 'sha256' or 'md5')
-     * - `salt` Boolean flag for salting the password in a hashes, and checks.
+     * - `salt` Boolean flag for salting the password in a hash, or check.
      *
      * @var array
      */

--- a/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/src/PasswordHasher/LegacyPasswordHasher.php
@@ -36,7 +36,7 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
      */
     protected $_defaultConfig = [
         'hashType' => null,
-        'salt' => null,
+        'salt' => true,
     ];
 
     /**
@@ -61,7 +61,7 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
      */
     public function hash($password): string
     {
-        return Security::hash($password, $this->_config['hashType'], ($this->_config['salt'] ?? true));
+        return Security::hash($password, $this->_config['hashType'], $this->_config['salt']);
     }
 
     /**

--- a/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/src/PasswordHasher/LegacyPasswordHasher.php
@@ -29,11 +29,14 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
 {
     /**
      * Default config for this object.
+     * - `hashType` String identifier of the hash type to use on the password. (e.g 'sha256' or 'md5')
+     * - `salt` Boolean flag for salting the password in a hashes, and checks.
      *
      * @var array
      */
     protected $_defaultConfig = [
         'hashType' => null,
+        'salt' => null
     ];
 
     /**
@@ -58,7 +61,7 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
      */
     public function hash($password): string
     {
-        return Security::hash($password, $this->_config['hashType'], true);
+        return Security::hash($password, $this->_config['hashType'], ($this->_config['salt'] ?? true));
     }
 
     /**

--- a/tests/TestCase/PasswordHasher/LegacyPasswordHasherTest.php
+++ b/tests/TestCase/PasswordHasher/LegacyPasswordHasherTest.php
@@ -65,5 +65,17 @@ class LegacyPasswordHasherTest extends TestCase
 
         $hasher->setConfig('hashType', 'sha1');
         $this->assertFalse($hasher->check('foo', $password));
+
+        // salt check
+        $hasher->setConfig('hashType', 'sha256');
+        $saltedPassword = $hasher->hash('saltcheck');
+        $this->assertTrue($hasher->check('saltcheck', $saltedPassword));
+        $hasher->setConfig('salt', false);
+        $this->assertFalse($hasher->check('saltcheck', $saltedPassword));
+
+        $unsaltedPassword = $hasher->hash('saltcheck');
+        $this->assertTrue($hasher->check('saltcheck', $unsaltedPassword));
+        $hasher->setConfig('salt', true);
+        $this->assertFalse($hasher->check('saltcheck', $unsaltedPassword));
     }
 }


### PR DESCRIPTION
Hello, I usually work in an environment that has various other vanilla PHP code touching the database, and when recently upgrading to Cake 4.x I needed to check passwords with no salt as we have in our older version of the Cake app which rely on components.

I had written a class in our code base which extends the LegacyPasswordHasher to not use a salt string when needed. I figured I would submit it here as a small feature, unless I missed where this plugin has this already, or standard way of integrating it.

Hope it helps!