### PR TITLE
Wrong getAuthenticationService() declaration

### DIFF
--- a/docs/en/migration-from-the-authcomponent.rst
+++ b/docs/en/migration-from-the-authcomponent.rst
@@ -88,7 +88,7 @@ service from your application::
          * @param \Psr\Http\Message\ResponseInterface $response Response
          * @return \Authentication\AuthenticationServiceInterface
          */
-        public function getAuthenticationService(ServerRequestInterface $request, ResponseInterface $response)
+        public function getAuthenticationService(ServerRequestInterface $request) : AuthenticationServiceInterface
         {
             $service = new AuthenticationService();
             // Configure the service. (see below for more details)


### PR DESCRIPTION
Got a 500 error with `PHP Fatal error:  Declaration of App\Application::getAuthenticationService(Psr\Http\Message\ServerRequestInterface $request, Psr\Http\Message\ResponseInterface $response): Authentication\AuthenticationServiceInterface must be compatible with Authentication\AuthenticationServiceProviderInterface::getAuthenticationService(Psr\Http\Message\ServerRequestInterface $request): Authentication\AuthenticationServiceInterface` when following current documentation.
