### PR TITLE
Fix broken Identifiers link

### DIFF
--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -20,7 +20,7 @@ Configuration options:
    ``Auth``
 -  **identify**: Set this key with a value of bool ``true`` to enable checking
    the session credentials against the identifiers. When ``true``, the configured
-   `Identifiers <./identifers.md>`__ are used to identify the user using data
+   :doc:`/identifiers` are used to identify the user using data
    stored in the session on each request. Default value is ``false``.
 -  **fields**: Allows you to map the ``username`` field to the unique
    identifier in your user storage. Defaults to ``username``. This option is


### PR DESCRIPTION
Follow-up to https://github.com/cakephp/authentication/pull/359

Fixes typo (identifers -> identif***i***ers), updates link to use same syntax as the rest of the docs.