### PR TITLE
Cake\Http\ServerRequest can't `serialize()` when Authentication.Orm resolver is used

### DIFF
--- a/src/Identifier/Resolver/OrmResolver.php
+++ b/src/Identifier/Resolver/OrmResolver.php
@@ -17,12 +17,11 @@ declare(strict_types=1);
 namespace Authentication\Identifier\Resolver;
 
 use Cake\Core\InstanceConfigTrait;
-use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\TableRegistry;
 
 class OrmResolver implements ResolverInterface
 {
     use InstanceConfigTrait;
-    use LocatorAwareTrait;
 
     /**
      * Default configuration.
@@ -54,7 +53,7 @@ class OrmResolver implements ResolverInterface
      */
     public function find(array $conditions, $type = self::TYPE_AND)
     {
-        $table = $this->getTableLocator()->get($this->_config['userModel']);
+        $table = TableRegistry::getTableLocator()->get($this->_config['userModel']);
 
         $query = $table->query();
         $finders = (array)$this->_config['finder'];

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -769,4 +769,39 @@ class AuthenticationMiddlewareTest extends TestCase
         $this->assertSame('redirect', $service->getConfig('queryParam'));
         $this->assertSame('/login', $service->getConfig('unauthenticatedRedirect'));
     }
+
+    /**
+     * Test Serializable Request Instance
+     *
+     * @return void
+     */
+    public function testSerializableRequestInstance()
+    {
+        $service = new AuthenticationService([
+            'identifiers' => [
+                'Authentication.Password' => [
+                    'resolver' => [
+                        'className' => 'Authentication.Orm',
+                        'userModel' => 'AuthUsers',
+                        'finder' => 'auth',
+                    ],
+                ],
+            ],
+            'authenticators' => [
+                'Authentication.Form',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/testpath'],
+            [],
+            ['username' => 'mariano', 'password' => 'password']
+        );
+        $handler = new TestRequestHandler();
+
+        $middleware = new AuthenticationMiddleware($service);
+        $middleware->process($request, $handler);
+
+        // serialize(): included PDO's instance throws Exception
+        $this->assertNotEmpty(serialize($handler->request));
+    }
 }


### PR DESCRIPTION
https://github.com/cakephp/authentication/issues/364

- [x] create unit test that generate error
- [x] fix up