### PR TITLE
Replace zendframework/zend-diactoros with laminas/laminas-diactoros.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     "homepage": "https://cakephp.org",
     "require": {
         "cakephp/core": "^4.0",
+        "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
-        "psr/http-server-middleware": "^1.0",
-        "zendframework/zend-diactoros": "^2.0"
+        "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "cakephp/cakephp": "^4.0",

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -24,14 +24,14 @@ use Authentication\Authenticator\StatelessInterface;
 use Authentication\Authenticator\UnauthenticatedException;
 use Cake\Core\InstanceConfigTrait;
 use InvalidArgumentException;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Laminas\Diactoros\Stream;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\Response\RedirectResponse;
-use Zend\Diactoros\Stream;
 
 /**
  * Authentication Middleware


### PR DESCRIPTION
Fixes https://github.com/cakephp/authentication/issues/385