### PR TITLE
Add samesite attribute and change spelling of config-key

### DIFF
--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -54,7 +54,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             'domain' => '',
             'secure' => false,
             'httponly' => false,
-            'samesite' => null,
+            'samesite' => null
         ],
         'passwordHasher' => 'Authentication.Default',
     ];
@@ -226,7 +226,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             $data['domain'],
             $data['secure'],
             $data['httponly'],
-            $data['samesite'],
+            $data['samesite']
         );
 
         return $cookie;

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -53,7 +53,8 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             'path' => '/',
             'domain' => '',
             'secure' => false,
-            'httpOnly' => false,
+            'httponly' => false,
+            'samesite' => null,
         ],
         'passwordHasher' => 'Authentication.Default',
     ];
@@ -224,7 +225,8 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             $data['path'],
             $data['domain'],
             $data['secure'],
-            $data['httpOnly']
+            $data['httponly'],
+            $data['samesite'],
         );
 
         return $cookie;

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -212,7 +212,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
     {
         $data = $this->getConfig('cookie');
         $name = $data['name'];
-        unset($data['name']);        
+        unset($data['name']);
 
         $cookie = Cookie::create(
             $name,

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -54,7 +54,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             'domain' => '',
             'secure' => false,
             'httponly' => false,
-            'samesite' => null,
+            'samesite' => null
         ],
         'passwordHasher' => 'Authentication.Default',
     ];

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -54,7 +54,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             'domain' => '',
             'secure' => false,
             'httponly' => false,
-            'samesite' => null
+            'samesite' => null,
         ],
         'passwordHasher' => 'Authentication.Default',
     ];

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -212,13 +212,12 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
     {
         $data = $this->getConfig('cookie');
         $name = $data['name'];
-        unset($data['name']);
-        $options = $data;
+        unset($data['name']);        
 
         $cookie = Cookie::create(
             $name,
             $value,
-            $options
+            $data
         );
 
         return $cookie;

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -48,13 +48,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             IdentifierInterface::CREDENTIAL_PASSWORD => 'password',
         ],
         'cookie' => [
-            'name' => 'CookieAuth',
-            'expire' => null,
-            'path' => '/',
-            'domain' => '',
-            'secure' => false,
-            'httponly' => false,
-            'samesite' => null,
+            'name' => 'CookieAuth',            
         ],
         'passwordHasher' => 'Authentication.Default',
     ];
@@ -217,16 +211,14 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
     protected function _createCookie($value): CookieInterface
     {
         $data = $this->getConfig('cookie');
+        $name = $data['name'];
+        unset($data['name']);
+        $options = $data;
 
-        $cookie = new Cookie(
-            $data['name'],
+        $cookie = Cookie::create(
+            $name,
             $value,
-            $data['expire'],
-            $data['path'],
-            $data['domain'],
-            $data['secure'],
-            $data['httponly'],
-            $data['samesite']
+            $options
         );
 
         return $cookie;

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -48,7 +48,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             IdentifierInterface::CREDENTIAL_PASSWORD => 'password',
         ],
         'cookie' => [
-            'name' => 'CookieAuth',            
+            'name' => 'CookieAuth',
         ],
         'passwordHasher' => 'Authentication.Default',
     ];


### PR DESCRIPTION
The samesite-attribute is missing in the configuration-array and the spelling of the config-key 'httpOnly' is deprecated in CookieInterface.