### PR TITLE
Revert "Add samesite attribute and change spelling of config-key (#394)"

### DIFF
--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -49,6 +49,11 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
         ],
         'cookie' => [
             'name' => 'CookieAuth',
+            'expire' => null,
+            'path' => '/',
+            'domain' => '',
+            'secure' => false,
+            'httpOnly' => false,
         ],
         'passwordHasher' => 'Authentication.Default',
     ];
@@ -211,13 +216,15 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
     protected function _createCookie($value): CookieInterface
     {
         $data = $this->getConfig('cookie');
-        $name = $data['name'];
-        unset($data['name']);
 
-        $cookie = Cookie::create(
-            $name,
+        $cookie = new Cookie(
+            $data['name'],
             $value,
-            $data
+            $data['expire'],
+            $data['path'],
+            $data['domain'],
+            $data['secure'],
+            $data['httpOnly']
         );
 
         return $cookie;


### PR DESCRIPTION
This reverts commit 3a86c889778f47de4e5a59e5a038753e6ca6a84b.

I was a bit hasty in merging #394. Given the key changes in core's `Cookie` class it's better to make these change in new minor instead of a bugfix release.

I'll make a new PR targetting `2.next` instead.