### PR TITLE
Use Cookie::create() instead of constructor to build cookie.

### DIFF
--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -245,7 +245,7 @@ Configuration options:
    -  **samesite**: String/null
 
    The defaults for the various options besides ``cookie.name`` will be those
-   set for the ``Cake\Http\Cookie\Cookie`` class. See [Cookie::setDefaults()](https://api.cakephp.org/4.0/class-Cake.Http.Cookie.Cookie.html#setDefaults)
+   set for the ``Cake\Http\Cookie\Cookie`` class. See `Cookie::setDefaults() <https://api.cakephp.org/4.0/class-Cake.Http.Cookie.Cookie.html#setDefaults>`_
    for the default values.
 
 -  **fields**: Array that maps ``username`` and ``password`` to the

--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -172,7 +172,7 @@ configuring your app as follows::
     ], [
         'controller' => '(jwks)',
     ]); // connect /.well-known/jwks.json to JwksController
-    
+
     // controller/JwksController.php
     public function index()
     {
@@ -192,7 +192,7 @@ configuring your app as follows::
         $this->set(compact('keys'));
         $this->viewBuilder()->setOption('serialize', 'keys');
     }
-    
+
 Refer to https://tools.ietf.org/html/rfc7517 or https://auth0.com/docs/tokens/concepts/jwks for
 more information about JWKS.
 
@@ -236,13 +236,17 @@ Configuration options:
 -  **rememberMeField**: Default is ``remember_me``
 -  **cookie**: Array of cookie options:
 
-   -  **name**: Cookie name, default is ``CookieAuth``
-   -  **expire**: Expiration, default is ``null``
-   -  **path**: Path, default is ``/``
-   -  **domain**: Domain, default is an empty string \`\`
-   -  **secure**: Bool, default is ``false``
-   -  **httpOnly**: Bool, default is ``false``
-   -  **value**: Value, default is an empty string \`\`
+   -  **name**: Cookie name, defaults is ``CookieAuth``
+   -  **expires**: Expiration
+   -  **path**: Path
+   -  **domain**: Domain
+   -  **secure**: Bool
+   -  **httponly**: Bool
+   -  **samesite**: String/null
+
+   The defaults for the various options besides ``cookie.name`` will be those
+   set for the ``Cake\Http\Cookie\Cookie`` class. See [Cookie::setDefaults()](https://api.cakephp.org/4.0/class-Cake.Http.Cookie.Cookie.html#setDefaults)
+   for the default values.
 
 -  **fields**: Array that maps ``username`` and ``password`` to the
    specified identity fields.

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -49,11 +49,6 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
         ],
         'cookie' => [
             'name' => 'CookieAuth',
-            'expire' => null,
-            'path' => '/',
-            'domain' => '',
-            'secure' => false,
-            'httpOnly' => false,
         ],
         'passwordHasher' => 'Authentication.Default',
     ];
@@ -215,16 +210,25 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
      */
     protected function _createCookie($value): CookieInterface
     {
-        $data = $this->getConfig('cookie');
+        $options = $this->getConfig('cookie');
+        $name = $options['name'];
+        unset($options['name']);
 
-        $cookie = new Cookie(
-            $data['name'],
+        if (array_key_exists('expire', $options)) {
+            deprecationWarning('Config key `expire` is deprecated, use `expires` instead.');
+            $options['expires'] = $options['expire'];
+            unset($options['expire']);
+        }
+        if (array_key_exists('httpOnly', $options)) {
+            deprecationWarning('Config key `httpOnly` is deprecated, use `httponly` instead.');
+            $options['httponly'] = $options['httpOnly'];
+            unset($options['httpOnly']);
+        }
+
+        $cookie = Cookie::create(
+            $name,
             $value,
-            $data['expire'],
-            $data['path'],
-            $data['domain'],
-            $data['secure'],
-            $data['httpOnly']
+            $options
         );
 
         return $cookie;

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -230,7 +230,10 @@ class CookieAuthenticatorTest extends TestCase
         ]);
         $response = new Response();
 
-        $authenticator = new CookieAuthenticator($identifiers);
+        Cookie::setDefaults(['samesite' => 'None']);
+        $authenticator = new CookieAuthenticator($identifiers, [
+            'cookie' => ['expires' => '2030-01-01 00:00:00'],
+        ]);
 
         $identity = new ArrayObject([
             'username' => 'mariano',
@@ -247,6 +250,16 @@ class CookieAuthenticatorTest extends TestCase
             'CookieAuth=%5B%22mariano%22%2C%22%242y%2410%24',
             $result['response']->getHeaderLine('Set-Cookie')
         );
+        $this->assertStringContainsString(
+            'expires=Tue, 01-Jan-2030 00:00:00 GMT;',
+            $result['response']->getHeaderLine('Set-Cookie')
+        );
+        $this->assertStringContainsString(
+            'samesite=None',
+            $result['response']->getHeaderLine('Set-Cookie')
+        );
+
+        Cookie::setDefaults(['samesite' => null]);
 
         // Testing that the field is not present
         $request = $request->withParsedBody([]);


### PR DESCRIPTION
The default options from the `cookie` config have been removed so that the defaults
set for Cake\Http\Cookie\Cookie are used.