### PR TITLE
Test enhancement about assertion Equals checking

### DIFF
--- a/src/Authenticator/AuthenticatorCollection.php
+++ b/src/Authenticator/AuthenticatorCollection.php
@@ -49,19 +49,19 @@ class AuthenticatorCollection extends AbstractCollection
     /**
      * Creates authenticator instance.
      *
-     * @param string $className Authenticator class.
+     * @param string $class Authenticator class.
      * @param string $alias Authenticator alias.
      * @param array $config Config array.
      * @return \Authentication\Authenticator\AuthenticatorInterface
      * @throws \RuntimeException
      */
-    protected function _create($className, string $alias, array $config): AuthenticatorInterface
+    protected function _create($class, string $alias, array $config): AuthenticatorInterface
     {
-        $authenticator = new $className($this->_identifiers, $config);
+        $authenticator = new $class($this->_identifiers, $config);
         if (!($authenticator instanceof AuthenticatorInterface)) {
             throw new RuntimeException(sprintf(
                 'Authenticator class `%s` must implement `%s`.',
-                $className,
+                $class,
                 AuthenticatorInterface::class
             ));
         }

--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -66,19 +66,19 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
     /**
      * Creates identifier instance.
      *
-     * @param string $className Identifier class.
+     * @param string $class Identifier class.
      * @param string $alias Identifier alias.
      * @param array $config Config array.
      * @return \Authentication\Identifier\IdentifierInterface
      * @throws \RuntimeException
      */
-    protected function _create($className, string $alias, array $config): IdentifierInterface
+    protected function _create($class, string $alias, array $config): IdentifierInterface
     {
-        $identifier = new $className($config);
+        $identifier = new $class($config);
         if (!($identifier instanceof IdentifierInterface)) {
             throw new RuntimeException(sprintf(
                 'Identifier class `%s` must implement `%s`.',
-                $className,
+                $class,
                 IdentifierInterface::class
             ));
         }

--- a/src/UrlChecker/DefaultUrlChecker.php
+++ b/src/UrlChecker/DefaultUrlChecker.php
@@ -40,11 +40,11 @@ class DefaultUrlChecker implements UrlCheckerInterface
     /**
      * @inheritDoc
      */
-    public function check(ServerRequestInterface $request, $urls, array $options = []): bool
+    public function check(ServerRequestInterface $request, $loginUrls, array $options = []): bool
     {
         $options = $this->_mergeDefaultOptions($options);
 
-        $urls = (array)$urls;
+        $urls = (array)$loginUrls;
 
         if (empty($urls)) {
             return true;

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -280,7 +280,7 @@ class AuthenticationServiceTest extends TestCase
         $this->assertInstanceOf(RequestInterface::class, $result['request']);
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
 
-        $this->assertEquals(
+        $this->assertSame(
             'florian',
             $result['request']->getAttribute('session')->read('Auth.username')
         );
@@ -326,7 +326,7 @@ class AuthenticationServiceTest extends TestCase
         $this->assertInstanceOf(RequestInterface::class, $result['request']);
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
 
-        $this->assertEquals(
+        $this->assertSame(
             'florian',
             $result['request']->getAttribute('session')->read('Auth.username')
         );
@@ -374,7 +374,7 @@ class AuthenticationServiceTest extends TestCase
         $this->assertInstanceOf(RequestInterface::class, $result['request']);
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
 
-        $this->assertEquals(
+        $this->assertSame(
             'florian',
             $result['request']->getAttribute('session')->read('Auth.username')
         );
@@ -546,7 +546,7 @@ class AuthenticationServiceTest extends TestCase
         // Authenticate an identity
         $service->authenticate($request);
         $this->assertInstanceOf(Identity::class, $service->getIdentity());
-        $this->assertEquals('by-callable', $service->getIdentity()->getIdentifier());
+        $this->assertSame('by-callable', $service->getIdentity()->getIdentifier());
     }
 
     /**

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -73,7 +73,7 @@ class CookieAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
     }
 
     /**
@@ -101,7 +101,7 @@ class CookieAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
     }
 
     /**
@@ -129,7 +129,7 @@ class CookieAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
     }
 
     /**
@@ -157,7 +157,7 @@ class CookieAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
     }
 
     /**
@@ -180,7 +180,7 @@ class CookieAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }
 
     /**
@@ -208,7 +208,7 @@ class CookieAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
     }
 
     /**
@@ -335,6 +335,6 @@ class CookieAuthenticatorTest extends TestCase
         $this->assertInstanceOf(RequestInterface::class, $result['request']);
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
 
-        $this->assertEquals('CookieAuth=; expires=Thu, 01-Jan-1970 00:00:01 UTC; path=/', $result['response']->getHeaderLine('Set-Cookie'));
+        $this->assertSame('CookieAuth=; expires=Thu, 01-Jan-1970 00:00:01 UTC; path=/', $result['response']->getHeaderLine('Set-Cookie'));
     }
 }

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -58,7 +58,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
     }
 
     /**
@@ -84,7 +84,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
         $this->assertEquals([0 => 'Login credentials not found'], $result->getErrors());
     }
 
@@ -111,7 +111,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
         $this->assertEquals([0 => 'Login credentials not found'], $result->getErrors());
     }
 
@@ -140,7 +140,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
         $this->assertEquals([0 => 'Login URL `http://localhost/users/does-not-match` did not match `/users/login`.'], $result->getErrors());
     }
 
@@ -172,7 +172,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
         $this->assertEquals([0 => 'Login URL `http://localhost/users/does-not-match` did not match `/en/users/login` or `/de/users/login`.'], $result->getErrors());
     }
 
@@ -205,7 +205,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
         $this->assertEquals([0 => 'Login URL `http://localhost/base/users/login` did not match `/users/login`.'], $result->getErrors());
     }
 
@@ -234,7 +234,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertEquals([], $result->getErrors());
     }
 
@@ -266,7 +266,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertEquals([], $result->getErrors());
     }
 
@@ -299,7 +299,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertEquals([], $result->getErrors());
     }
 
@@ -331,7 +331,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertEquals([], $result->getErrors());
     }
 
@@ -366,7 +366,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
         $this->assertEquals([0 => 'Login URL `http://localhost/de/users/login` did not match `%auth\.localhost/[a-z]{2}/users/login/?$%`.'], $result->getErrors());
     }
 
@@ -402,7 +402,7 @@ class FormAuthenticatorTest extends TestCase
         $result = $form->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertEquals([], $result->getErrors());
     }
 

--- a/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
@@ -67,7 +67,7 @@ class HttpBasicAuthenticatorTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals('AuthUser', $object->getConfig('userModel'));
+        $this->assertSame('AuthUser', $object->getConfig('userModel'));
         $this->assertEquals(['username' => 'user', 'password' => 'password'], $object->getConfig('fields'));
     }
 
@@ -205,7 +205,7 @@ class HttpBasicAuthenticatorTest extends TestCase
         } catch (AuthenticationRequiredException $e) {
             $expected = ['WWW-Authenticate' => 'Basic realm="localhost"'];
             $this->assertEquals($expected, $e->getHeaders());
-            $this->assertEquals(401, $e->getCode());
+            $this->assertSame(401, $e->getCode());
         }
     }
 

--- a/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
@@ -84,9 +84,9 @@ class HttpDigestAuthenticatorTest extends TestCase
             'secret' => 'foo.bar',
         ]);
 
-        $this->assertEquals('AuthUser', $object->getConfig('userModel'));
+        $this->assertSame('AuthUser', $object->getConfig('userModel'));
         $this->assertEquals(['username' => 'user', 'password' => 'pass'], $object->getConfig('fields'));
-        $this->assertEquals(123456, $object->getConfig('nonce'));
+        $this->assertSame(123456, $object->getConfig('nonce'));
         $this->assertEquals(env('SERVER_NAME'), $object->getConfig('realm'));
         $this->assertInstanceOf(StatelessInterface::class, $object, 'Should be a stateless authenticator');
     }
@@ -284,7 +284,7 @@ DIGEST;
             $this->auth->unauthorizedChallenge($request);
             $this->fail('Should challenge');
         } catch (AuthenticationRequiredException $e) {
-            $this->assertEquals(401, $e->getCode());
+            $this->assertSame(401, $e->getCode());
             $header = $e->getHeaders()['WWW-Authenticate'];
             $this->assertRegexp(
                 '/^Digest realm="localhost",qop="auth",nonce="[A-Za-z0-9=]+",opaque="123abc"$/',
@@ -469,7 +469,7 @@ DIGEST;
     {
         $result = HttpDigestAuthenticator::password('mark', 'password', 'localhost');
         $expected = md5('mark:localhost:password');
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
@@ -91,7 +91,7 @@ class JwtAuthenticatorTest extends TestCase
 
         $result = $authenticator->authenticate($this->request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertInstanceOf(ArrayAccess::class, $result->getData());
     }
 
@@ -114,7 +114,7 @@ class JwtAuthenticatorTest extends TestCase
 
         $result = $authenticator->authenticate($this->request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertInstanceOf(ArrayAccess::class, $result->getData());
     }
 
@@ -151,7 +151,7 @@ class JwtAuthenticatorTest extends TestCase
 
         $result = $authenticator->authenticate($this->request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertInstanceOf(ArrayAccess::class, $result->getData());
     }
 
@@ -186,7 +186,7 @@ class JwtAuthenticatorTest extends TestCase
 
         $result = $authenticator->authenticate($request, $response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
         $this->assertNull($result->getData());
     }
 
@@ -219,7 +219,7 @@ class JwtAuthenticatorTest extends TestCase
 
         $result = $authenticator->authenticate($request, $response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
         $this->assertNUll($result->getData());
     }
 
@@ -236,7 +236,7 @@ class JwtAuthenticatorTest extends TestCase
 
         $result = $authenticator->authenticate($this->request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
         $this->assertNUll($result->getData());
         $errors = $result->getErrors();
         $this->assertArrayHasKey('message', $errors);

--- a/tests/TestCase/Authenticator/ResultTest.php
+++ b/tests/TestCase/Authenticator/ResultTest.php
@@ -104,11 +104,11 @@ class ResultTest extends TestCase
     public function testGetCode()
     {
         $result = new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
-        $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
 
         $entity = new Entity(['user' => 'florian']);
         $result = new Result($entity, Result::SUCCESS);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
     }
 
     /**

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -83,7 +83,7 @@ class SessionAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
 
         $this->sessionMock->expects($this->at(0))
             ->method('read')
@@ -96,7 +96,7 @@ class SessionAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
     }
 
     /**
@@ -125,7 +125,7 @@ class SessionAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
 
         $this->sessionMock->expects($this->at(0))
             ->method('read')
@@ -143,7 +143,7 @@ class SessionAuthenticatorTest extends TestCase
         $result = $authenticator->authenticate($request, $response);
 
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
     }
 
     /**

--- a/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
@@ -70,7 +70,7 @@ class TokenAuthenticatorTest extends TestCase
         ]);
         $result = $tokenAuth->authenticate($this->request, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
 
         // Test header token
         $requestWithHeaders = $this->request->withAddedHeader('Token', 'mariano');
@@ -79,7 +79,7 @@ class TokenAuthenticatorTest extends TestCase
         ]);
         $result = $tokenAuth->authenticate($requestWithHeaders, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
     }
 
     /**
@@ -96,7 +96,7 @@ class TokenAuthenticatorTest extends TestCase
         ]);
         $result = $tokenAuth->authenticate($requestWithParams, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
 
         // Test with valid query param but invalid token
         $requestWithParams = $this->request->withQueryParams(['token' => 'does-not-exist']);
@@ -105,7 +105,7 @@ class TokenAuthenticatorTest extends TestCase
         ]);
         $result = $tokenAuth->authenticate($requestWithParams, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
     }
 
     /**
@@ -123,7 +123,7 @@ class TokenAuthenticatorTest extends TestCase
         ]);
         $result = $tokenAuth->authenticate($requestWithHeaders, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::SUCCESS, $result->getStatus());
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
 
         //invalid prefix
         $requestWithHeaders = $this->request->withAddedHeader('Token', 'bearer mariano');
@@ -133,7 +133,7 @@ class TokenAuthenticatorTest extends TestCase
         ]);
         $result = $tokenAuth->authenticate($requestWithHeaders, $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
     }
 
     /**
@@ -149,7 +149,7 @@ class TokenAuthenticatorTest extends TestCase
 
         $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals(), $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }
 
     /**
@@ -165,7 +165,7 @@ class TokenAuthenticatorTest extends TestCase
 
         $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals(), $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }
 
     /**
@@ -179,6 +179,6 @@ class TokenAuthenticatorTest extends TestCase
 
         $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals(), $this->response);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }
 }

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -160,7 +160,7 @@ class AuthenticationComponentTest extends TestCase
 
         $result = $component->getIdentity();
         $this->assertInstanceOf(IdentityInterface::class, $result);
-        $this->assertEquals('florian', $result->username);
+        $this->assertSame('florian', $result->username);
     }
 
     /**
@@ -181,7 +181,7 @@ class AuthenticationComponentTest extends TestCase
 
         $result = $component->getIdentity();
         $this->assertInstanceOf(IdentityInterface::class, $result);
-        $this->assertEquals('florian', $result->username);
+        $this->assertSame('florian', $result->username);
     }
 
     /**
@@ -253,7 +253,7 @@ class AuthenticationComponentTest extends TestCase
         $component = new AuthenticationComponent($registry);
 
         $result = $component->getIdentityData('profession');
-        $this->assertEquals('developer', $result);
+        $this->assertSame('developer', $result);
     }
 
     /**
@@ -311,11 +311,11 @@ class AuthenticationComponentTest extends TestCase
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
-        $this->assertEquals('florian', $controller->getRequest()->getAttribute('identity')->username);
+        $this->assertSame('florian', $controller->getRequest()->getAttribute('identity')->username);
         $component->logout();
         $this->assertNull($controller->getRequest()->getAttribute('identity'));
         $this->assertInstanceOf(Event::class, $result);
-        $this->assertEquals('Authentication.logout', $result->getName());
+        $this->assertSame('Authentication.logout', $result->getName());
     }
 
     /**
@@ -365,7 +365,7 @@ class AuthenticationComponentTest extends TestCase
         $controller->startupProcess();
 
         $this->assertInstanceOf(Event::class, $result);
-        $this->assertEquals('Authentication.afterIdentify', $result->getName());
+        $this->assertSame('Authentication.afterIdentify', $result->getName());
         $this->assertNotEmpty($result->getData());
         $this->assertInstanceOf(AuthenticatorInterface::class, $result->getData('provider'));
         $this->assertInstanceOf(IdentityInterface::class, $result->getData('identity'));

--- a/tests/TestCase/Identifier/CallbackIdentifierTest.php
+++ b/tests/TestCase/Identifier/CallbackIdentifierTest.php
@@ -134,7 +134,7 @@ class CallbackIdentifierTest extends TestCase
         $result = $identifier->identify(['username' => 'florian']);
 
         $this->assertInstanceOf(Entity::class, $result);
-        $this->assertEquals('florian', $result->username);
+        $this->assertSame('florian', $result->username);
 
         $result = $identifier->identify(['username' => 'larry']);
 

--- a/tests/TestCase/Identifier/Resolver/OrmResolverTest.php
+++ b/tests/TestCase/Identifier/Resolver/OrmResolverTest.php
@@ -31,7 +31,7 @@ class OrmResolverTest extends AuthenticationTestCase
         ]);
 
         $this->assertInstanceOf(EntityInterface::class, $user);
-        $this->assertEquals('mariano', $user['username']);
+        $this->assertSame('mariano', $user['username']);
     }
 
     public function testFindConfig()
@@ -60,7 +60,7 @@ class OrmResolverTest extends AuthenticationTestCase
             'username' => 'mariano',
         ]);
 
-        $this->assertEquals(1, $user['id']);
+        $this->assertSame(1, $user['id']);
     }
 
     public function testFindOr()
@@ -72,7 +72,7 @@ class OrmResolverTest extends AuthenticationTestCase
             'username' => 'luigiano',
         ], 'OR');
 
-        $this->assertEquals(1, $user['id']);
+        $this->assertSame(1, $user['id']);
     }
 
     public function testFindMissing()
@@ -98,6 +98,6 @@ class OrmResolverTest extends AuthenticationTestCase
             ],
         ]);
 
-        $this->assertEquals(1, $user['id']);
+        $this->assertSame(1, $user['id']);
     }
 }

--- a/tests/TestCase/IdentityTest.php
+++ b/tests/TestCase/IdentityTest.php
@@ -39,9 +39,9 @@ class IdentityTest extends TestCase
         $identity = new Identity($data);
 
         $result = $identity->getIdentifier();
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
 
-        $this->assertEquals('florian', $identity->username);
+        $this->assertSame('florian', $identity->username);
     }
 
     /**
@@ -116,7 +116,7 @@ class IdentityTest extends TestCase
     {
         $data = ['username' => 'robert'];
         $identity = new Identity($data);
-        $this->assertEquals($data['username'], $identity['username']);
+        $this->assertSame($data['username'], $identity['username']);
     }
 
     public function testBuildInvalidArgument()

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -220,7 +220,7 @@ class AuthenticationMiddlewareTest extends TestCase
             /** @var \Authentication\AuthenticationService $service */
             $service = $req->getAttribute('authentication');
             $this->assertInstanceOf(AuthenticationService::class, $service);
-            $this->assertEquals('customIdentity', $service->getConfig('identityAttribute'));
+            $this->assertSame('customIdentity', $service->getConfig('identityAttribute'));
             $this->assertTrue($service->identifiers()->has('Password'));
             $this->assertTrue($service->authenticators()->has('Form'));
 
@@ -376,7 +376,7 @@ class AuthenticationMiddlewareTest extends TestCase
         $middleware = new AuthenticationMiddleware($service);
 
         $response = $middleware->process($request, $handler);
-        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertSame(401, $response->getStatusCode());
         $this->assertTrue($response->hasHeader('WWW-Authenticate'));
         $this->assertSame('', $response->getBody()->getContents());
     }

--- a/tests/TestCase/View/Helper/IdentityHelperTest.php
+++ b/tests/TestCase/View/Helper/IdentityHelperTest.php
@@ -65,12 +65,12 @@ class IdentityHelperTest extends TestCase
         $view = new View($request);
 
         $helper = new IdentityHelper($view);
-        $this->assertEquals(1, $helper->get('id'));
-        $this->assertEquals('cake', $helper->get('profile.first_name'));
+        $this->assertSame(1, $helper->get('id'));
+        $this->assertSame('cake', $helper->get('profile.first_name'));
         $this->assertEquals($identity->getOriginalData(), $helper->get());
 
         $this->assertTrue($helper->isLoggedIn());
-        $this->assertEquals(1, $helper->getId());
+        $this->assertSame(1, $helper->getId());
 
         $this->assertTrue($helper->is(1));
         $this->assertFalse($helper->is(2));


### PR DESCRIPTION
# Changed log

- Replace `assertEquals` with `assertSame` to make assertion equals checking strict.
- The `Psalm` reports static analysis error during Travis CI building and fix undefined variable and defined types.