### PR TITLE
Add ^1.0 into composer require command

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -6,7 +6,7 @@ Project's ROOT directory (where the **composer.json** file is located)
 
 .. code-block:: bash
 
-    php composer.phar require cakephp/authentication
+    php composer.phar require "cakephp/authentication:^1.0"
 
 Load the plugin by adding the following statement in your project's ``src/Application.php``::
 

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ You can install this plugin into your CakePHP application using
 [composer](https://getcomposer.org):
 
 ```
-php composer.phar require cakephp/authentication
+php composer.phar require "cakephp/authentication:^1.0"
 ```
 
 Load the plugin by adding the following statement in your project's


### PR DESCRIPTION
Currently `composer require cakephp/authentication` command throws error if we try to install in Cake 3.* project.

```bash
➜  cakephp-pingcrm git:(master) ✗ composer require cakephp/authentication       
Using version ^2.3 for cakephp/authentication
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for cakephp/authentication ^2.3 -> satisfiable by cakephp/authentication[2.3.0].
    - Conclusion: remove cakephp/cakephp 3.9.2
    - Conclusion: don't install cakephp/cakephp 3.9.2
    - cakephp/authentication 2.3.0 requires cakephp/core ^4.0 -> satisfiable by cakephp/core[4.0.0, 4.0.1, 4.0.2, 4.0.3, 4.0.4, 4.0.5, 4.0.6, 4.0.7, 4.0.8, 4.0.9, 4.1.0, 4.1.1, 4.1.2, 4.1.3, 4.1.4].
    - don't install cakephp/core 4.0.0|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.0.1|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.0.2|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.0.3|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.0.4|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.0.5|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.0.6|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.0.7|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.0.8|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.0.9|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.1.0|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.1.1|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.1.2|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.1.3|don't install cakephp/cakephp 3.9.2
    - don't install cakephp/core 4.1.4|don't install cakephp/cakephp 3.9.2
    - Installation request for cakephp/cakephp (locked at 3.9.2, required as 3.9.*) -> satisfiable by cakephp/cakephp[3.9.2].


Installation failed, reverting ./composer.json to its original content.
```

So we should add `^1.0` flag into the documentation to make installation process smoother.