### PR TITLE
Remove unneeded check and update testcase.

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -247,9 +247,7 @@ class AuthenticationService implements AuthenticationServiceInterface
             }
         }
 
-        if (!($identity instanceof IdentityInterface)) {
-            $identity = $this->buildIdentity($identity);
-        }
+        $identity = $this->buildIdentity($identity);
 
         return [
             'request' => $request->withAttribute($this->getConfig('identityAttribute'), $identity),

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -396,13 +396,13 @@ class AuthenticationServiceTest extends TestCase
     {
         $request = new ServerRequest();
         $response = new Response();
-        $identity = $this->createMock(IdentityInterface::class);
+        $identity = new ArrayObject();
 
         $service = new AuthenticationService();
 
         $result = $service->persistIdentity($request, $response, $identity);
 
-        $this->assertSame($identity, $result['request']->getAttribute('identity'));
+        $this->assertInstanceOf(IdentityInterface::class, $result['request']->getAttribute('identity'));
     }
 
     /**


### PR DESCRIPTION
PersistenceInterface::persistIdentity() doesn't accept IdentityInterface instance,
hence AuthenticationService::persistIdentity() cannot either.