### PR TITLE
Fix 500 errors when handling unauthenticated errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "type": "cakephp-plugin",
     "homepage": "https://cakephp.org",
     "require": {
-        "cakephp/core": "^4.0",
+        "cakephp/http": "^4.0",
         "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
@@ -18,10 +18,9 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "^4.0",
         "cakephp/cakephp-codesniffer": "^4.0",
-        "phpunit/phpunit": "^8.0",
-        "firebase/php-jwt": "^5.0"
+        "firebase/php-jwt": "^5.0",
+        "phpunit/phpunit": "^8.5 || ^9.3"
     },
     "suggest": {
         "cakephp/orm": "To use \"OrmResolver\" (Not needed separately if using full CakePHP framework).",

--- a/src/Authenticator/UnauthenticatedException.php
+++ b/src/Authenticator/UnauthenticatedException.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Authentication\Authenticator;
 
-use RuntimeException;
+use Cake\Http\Exception\HttpException;
 use Throwable;
 
 /**
@@ -26,7 +26,7 @@ use Throwable;
  * uses the 401 status code by default as this exception is used when the application
  * has rejected a request but we do not know which authenticator the user should try.
  */
-class UnauthenticatedException extends RuntimeException
+class UnauthenticatedException extends HttpException
 {
     /**
      * Constructor


### PR DESCRIPTION
The changes made in 4.2 that constrict which exceptions can set HTTP status codes requires this exception to extend HttpException. This requires a different package to be required.

Fixes #428