### PR TITLE
Allow customizing identity attribute in helper.

### DIFF
--- a/src/View/Helper/IdentityHelper.php
+++ b/src/View/Helper/IdentityHelper.php
@@ -28,6 +28,17 @@ use RuntimeException;
 class IdentityHelper extends Helper
 {
     /**
+     * Configuration options
+     *
+     * - `identityAttribute` - The request attribute which holds the identity.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'identityAttribute' => 'identity',
+    ];
+
+    /**
      * Identity Object
      *
      * @var null|\Authentication\IdentityInterface
@@ -44,7 +55,7 @@ class IdentityHelper extends Helper
      */
     public function initialize(array $config): void
     {
-        $this->_identity = $this->getView()->getRequest()->getAttribute('identity');
+        $this->_identity = $this->_View->getRequest()->getAttribute($this->getConfig('identityAttribute'));
 
         if (empty($this->_identity)) {
             return;

--- a/tests/TestCase/View/Helper/IdentityHelperTest.php
+++ b/tests/TestCase/View/Helper/IdentityHelperTest.php
@@ -76,6 +76,22 @@ class IdentityHelperTest extends TestCase
         $this->assertFalse($helper->is(2));
     }
 
+    public function testIdentityWithCustomAttribute()
+    {
+        $identity = new Identity([
+            'id' => 1,
+            'username' => 'cakephp',
+            'profile' => [
+                'first_name' => 'cake',
+            ],
+        ]);
+        $request = (new ServerRequest())->withAttribute('customIdentity', $identity);
+        $view = new View($request);
+
+        $helper = new IdentityHelper($view, ['identityAttribute' => 'customIdentity']);
+        $this->assertEquals($identity->getOriginalData(), $helper->get());
+    }
+
     /**
      * testWithOutIdentity
      *


### PR DESCRIPTION
Without this change one can't used the helper if the identity attribute is customized in the AuthenticationService.