### PR TITLE
Removed extra arguments when calling authenticator() in the test code

### DIFF
--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -67,10 +67,9 @@ class CookieAuthenticatorTest extends TestCase
                 'CookieAuth' => '["$2y$10$1bE1SgasKoz9WmEvUfuZLeYa6pQgxUIJ5LAoS/KGmC1hNuWkUG7ES"]',
             ]
         );
-        $response = new Response();
 
         $authenticator = new CookieAuthenticator($identifiers);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
@@ -95,10 +94,9 @@ class CookieAuthenticatorTest extends TestCase
                 'CookieAuth' => '["mariano","$2y$10$1bE1SgasKoz9WmEvUfuZLeYa6pQgxUIJ5LAoS/KGmC1hNuWkUG7ES"]',
             ]
         );
-        $response = new Response();
 
         $authenticator = new CookieAuthenticator($identifiers);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -123,10 +121,9 @@ class CookieAuthenticatorTest extends TestCase
                 'CookieAuth' => ['mariano', '$2y$10$1bE1SgasKoz9WmEvUfuZLeYa6pQgxUIJ5LAoS/KGmC1hNuWkUG7ES'],
             ]
         );
-        $response = new Response();
 
         $authenticator = new CookieAuthenticator($identifiers);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -151,10 +148,9 @@ class CookieAuthenticatorTest extends TestCase
                 'CookieAuth' => '["robert","$2y$10$1bE1SgasKoz9WmEvUfuZLeYa6pQgxUIJ5LAoS/KGmC1hNuWkUG7ES"]',
             ]
         );
-        $response = new Response();
 
         $authenticator = new CookieAuthenticator($identifiers);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
@@ -174,10 +170,9 @@ class CookieAuthenticatorTest extends TestCase
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/testpath']
         );
-        $response = new Response();
 
         $authenticator = new CookieAuthenticator($identifiers);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
@@ -202,10 +197,9 @@ class CookieAuthenticatorTest extends TestCase
                 'CookieAuth' => '["mariano","$2y$10$1bE1SgasKoz9WmEvUfuZLeYa6pQgxUIJ5LAoS/asdasdsadasd"]',
             ]
         );
-        $response = new Response();
 
         $authenticator = new CookieAuthenticator($identifiers);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -20,7 +20,6 @@ use Authentication\Authenticator\FormAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
-use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use RuntimeException;
 
@@ -52,10 +51,9 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers);
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -77,11 +75,10 @@ class FormAuthenticatorTest extends TestCase
             [],
             []
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
@@ -104,11 +101,10 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => '', 'password' => '']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
@@ -131,13 +127,12 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/users/login',
         ]);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
@@ -160,7 +155,6 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => [
@@ -169,7 +163,7 @@ class FormAuthenticatorTest extends TestCase
             ],
         ]);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
@@ -196,13 +190,12 @@ class FormAuthenticatorTest extends TestCase
         $uri->base = '/base';
         $request = $request->withUri($uri);
         $request = $request->withAttribute('base', $uri->base);
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/users/login',
         ]);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
@@ -225,13 +218,12 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/Users/login',
         ]);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -254,7 +246,6 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => [
@@ -263,7 +254,7 @@ class FormAuthenticatorTest extends TestCase
             ],
         ]);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -290,13 +281,12 @@ class FormAuthenticatorTest extends TestCase
         $uri->base = '/base';
         $request = $request->withUri($uri);
         $request = $request->withAttribute('base', $uri->base);
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/base/users/login',
         ]);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -319,7 +309,6 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '%^/[a-z]{2}/users/login/?$%',
@@ -328,7 +317,7 @@ class FormAuthenticatorTest extends TestCase
             ],
         ]);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -353,7 +342,6 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '%auth\.localhost/[a-z]{2}/users/login/?$%',
@@ -363,7 +351,7 @@ class FormAuthenticatorTest extends TestCase
             ],
         ]);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
@@ -389,7 +377,6 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '%auth\.localhost/[a-z]{2}/users/login/?$%',
@@ -399,7 +386,7 @@ class FormAuthenticatorTest extends TestCase
             ],
         ]);
 
-        $result = $form->authenticate($request, $response);
+        $result = $form->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -420,7 +407,6 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['email' => 'mariano@cakephp.org', 'secret' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/users/login',
@@ -441,7 +427,7 @@ class FormAuthenticatorTest extends TestCase
                 'password' => 'password',
             ]);
 
-        $form->authenticate($request, $response);
+        $form->authenticate($request);
     }
 
     /**
@@ -458,7 +444,6 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['id' => 1, 'username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/users/login',
@@ -475,7 +460,7 @@ class FormAuthenticatorTest extends TestCase
                 'password' => 'password',
             ]);
 
-        $form->authenticate($request, $response);
+        $form->authenticate($request);
     }
 
     /**
@@ -492,7 +477,6 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['id' => 1, 'username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/users/login',
@@ -502,7 +486,7 @@ class FormAuthenticatorTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('URL checker class `Foo` was not found.');
 
-        $form->authenticate($request, $response);
+        $form->authenticate($request);
     }
 
     /**
@@ -519,7 +503,6 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['id' => 1, 'username' => 'mariano', 'password' => 'password']
         );
-        $response = new Response();
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/users/login',
@@ -532,6 +515,6 @@ class FormAuthenticatorTest extends TestCase
             'does not implement the `Authentication\UrlChecker\UrlCheckerInterface` interface.'
         );
 
-        $form->authenticate($request, $response);
+        $form->authenticate($request);
     }
 }

--- a/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
@@ -20,7 +20,6 @@ use Authentication\Authenticator\AuthenticationRequiredException;
 use Authentication\Authenticator\HttpBasicAuthenticator;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
-use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
@@ -49,7 +48,6 @@ class HttpBasicAuthenticatorTest extends TestCase
         ]);
 
         $this->auth = new HttpBasicAuthenticator($this->identifiers);
-        $this->response = new Response();
     }
 
     /**
@@ -84,7 +82,7 @@ class HttpBasicAuthenticatorTest extends TestCase
             ]
         );
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertFalse($result->isValid());
     }
 
@@ -102,7 +100,7 @@ class HttpBasicAuthenticatorTest extends TestCase
             ]
         );
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertFalse($result->isValid());
     }
 
@@ -120,7 +118,7 @@ class HttpBasicAuthenticatorTest extends TestCase
             ]
         );
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertFalse($result->isValid());
     }
 
@@ -139,7 +137,7 @@ class HttpBasicAuthenticatorTest extends TestCase
             ]
         );
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertFalse($result->isValid());
     }
 
@@ -175,7 +173,7 @@ class HttpBasicAuthenticatorTest extends TestCase
             'created' => new Time('2007-03-17 01:16:23'),
             'updated' => new Time('2007-03-17 01:18:31'),
         ];
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertTrue($result->isValid());
 
         $value = $result->getData()->toArray();
@@ -224,7 +222,7 @@ class HttpBasicAuthenticatorTest extends TestCase
             ]
         );
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $expected = [
             'id' => 1,
             'username' => 'mariano',

--- a/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
@@ -22,7 +22,6 @@ use Authentication\Authenticator\HttpDigestAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Authenticator\StatelessInterface;
 use Authentication\Identifier\IdentifierCollection;
-use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
@@ -66,8 +65,6 @@ class HttpDigestAuthenticatorTest extends TestCase
         $password = HttpDigestAuthenticator::password('mariano', 'cake', 'localhost');
         $User = TableRegistry::get('Users');
         $User->updateAll(['password' => $password], []);
-
-        $this->response = $this->getMockBuilder(Response::class)->getMock();
     }
 
     /**
@@ -102,7 +99,7 @@ class HttpDigestAuthenticatorTest extends TestCase
             ['REQUEST_URI' => '/posts/index']
         );
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isValid());
     }
@@ -133,7 +130,7 @@ opaque="123abc"
 DIGEST;
         $_SERVER['PHP_AUTH_DIGEST'] = $digest;
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertFalse($result->isValid(), 'Should fail');
     }
 
@@ -163,7 +160,7 @@ DIGEST;
             ]
         );
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $expected = [
             'id' => 1,
             'username' => 'mariano',
@@ -206,7 +203,7 @@ DIGEST;
             ]
         );
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isValid());
     }
@@ -237,7 +234,7 @@ DIGEST;
             ]
         );
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isValid());
     }
@@ -264,7 +261,7 @@ DIGEST;
         $data['response'] = $this->auth->generateResponseHash($data, '09faa9931501bf30f0d4253fa7763022', 'GET');
         $request = $request->withEnv('PHP_AUTH_DIGEST', $this->digestHeader($data));
 
-        $result = $this->auth->authenticate($request, $this->response);
+        $result = $this->auth->authenticate($request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isValid());
     }

--- a/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
@@ -22,7 +22,6 @@ use Authentication\Authenticator\JwtAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
-use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Exception;
 use Firebase\JWT\JWT;
@@ -69,7 +68,6 @@ class JwtAuthenticatorTest extends TestCase
 
         $this->token = JWT::encode($data, 'secretKey');
         $this->identifiers = new IdentifierCollection([]);
-        $this->response = new Response();
     }
 
     /**
@@ -89,7 +87,7 @@ class JwtAuthenticatorTest extends TestCase
             'subjectKey' => 'subjectId',
         ]);
 
-        $result = $authenticator->authenticate($this->request, $this->response);
+        $result = $authenticator->authenticate($this->request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertInstanceOf(ArrayAccess::class, $result->getData());
@@ -112,7 +110,7 @@ class JwtAuthenticatorTest extends TestCase
             'subjectKey' => 'subjectId',
         ]);
 
-        $result = $authenticator->authenticate($this->request, $this->response);
+        $result = $authenticator->authenticate($this->request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertInstanceOf(ArrayAccess::class, $result->getData());
@@ -149,7 +147,7 @@ class JwtAuthenticatorTest extends TestCase
             'subjectKey' => 'subjectId',
         ]);
 
-        $result = $authenticator->authenticate($this->request, $this->response);
+        $result = $authenticator->authenticate($this->request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertInstanceOf(ArrayAccess::class, $result->getData());
@@ -169,8 +167,6 @@ class JwtAuthenticatorTest extends TestCase
             ['token' => $this->token]
         );
 
-        $response = new Response();
-
         $authenticator = $this->getMockBuilder(JwtAuthenticator::class)
             ->setConstructorArgs([
                 $this->identifiers,
@@ -184,7 +180,7 @@ class JwtAuthenticatorTest extends TestCase
             ->method('getPayLoad')
             ->willThrowException(new Exception());
 
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
         $this->assertNull($result->getData());
@@ -202,8 +198,6 @@ class JwtAuthenticatorTest extends TestCase
             ['token' => $this->token]
         );
 
-        $response = new Response();
-
         $authenticator = $this->getMockBuilder(JwtAuthenticator::class)
             ->setConstructorArgs([
                 $this->identifiers,
@@ -217,7 +211,7 @@ class JwtAuthenticatorTest extends TestCase
             ->method('getPayLoad')
             ->will($this->returnValue(new \stdClass()));
 
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
         $this->assertNUll($result->getData());
@@ -234,7 +228,7 @@ class JwtAuthenticatorTest extends TestCase
             'secretKey' => 'secretKey',
         ]);
 
-        $result = $authenticator->authenticate($this->request, $this->response);
+        $result = $authenticator->authenticate($this->request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());
         $this->assertNUll($result->getData());
@@ -263,7 +257,7 @@ class JwtAuthenticatorTest extends TestCase
         $result = $authenticator->getPayload();
         $this->assertNull($result);
 
-        $authenticator->authenticate($this->request, $this->response);
+        $authenticator->authenticate($this->request);
 
         $expected = [
             'subjectId' => 3,

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -67,7 +67,6 @@ class SessionAuthenticatorTest extends TestCase
     public function testAuthenticate()
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
-        $response = new Response();
 
         $this->sessionMock->expects($this->at(0))
             ->method('read')
@@ -80,7 +79,7 @@ class SessionAuthenticatorTest extends TestCase
         $request = $request->withAttribute('session', $this->sessionMock);
 
         $authenticator = new SessionAuthenticator($this->identifiers);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -93,7 +92,7 @@ class SessionAuthenticatorTest extends TestCase
         $request = $request->withAttribute('session', $this->sessionMock);
 
         $authenticator = new SessionAuthenticator($this->identifiers);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
@@ -107,7 +106,6 @@ class SessionAuthenticatorTest extends TestCase
     public function testVerifyByDatabase()
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
-        $response = new Response();
 
         $this->sessionMock->expects($this->at(0))
             ->method('read')
@@ -122,7 +120,7 @@ class SessionAuthenticatorTest extends TestCase
         $authenticator = new SessionAuthenticator($this->identifiers, [
             'identify' => true,
         ]);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
@@ -140,7 +138,7 @@ class SessionAuthenticatorTest extends TestCase
         $authenticator = new SessionAuthenticator($this->identifiers, [
             'identify' => true,
         ]);
-        $result = $authenticator->authenticate($request, $response);
+        $result = $authenticator->authenticate($request);
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_INVALID, $result->getStatus());

--- a/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
@@ -20,7 +20,6 @@ use Authentication\Authenticator\Result;
 use Authentication\Authenticator\TokenAuthenticator;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
-use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 
 class TokenAuthenticatorTest extends TestCase
@@ -53,8 +52,6 @@ class TokenAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-
-        $this->response = new Response();
     }
 
     /**
@@ -68,7 +65,7 @@ class TokenAuthenticatorTest extends TestCase
         $tokenAuth = new TokenAuthenticator($this->identifiers, [
             'queryParam' => 'token',
         ]);
-        $result = $tokenAuth->authenticate($this->request, $this->response);
+        $result = $tokenAuth->authenticate($this->request);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
 
@@ -77,7 +74,7 @@ class TokenAuthenticatorTest extends TestCase
         $tokenAuth = new TokenAuthenticator($this->identifiers, [
             'header' => 'Token',
         ]);
-        $result = $tokenAuth->authenticate($requestWithHeaders, $this->response);
+        $result = $tokenAuth->authenticate($requestWithHeaders);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
     }
@@ -94,7 +91,7 @@ class TokenAuthenticatorTest extends TestCase
         $tokenAuth = new TokenAuthenticator($this->identifiers, [
             'queryParam' => 'token',
         ]);
-        $result = $tokenAuth->authenticate($requestWithParams, $this->response);
+        $result = $tokenAuth->authenticate($requestWithParams);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
 
@@ -103,7 +100,7 @@ class TokenAuthenticatorTest extends TestCase
         $tokenAuth = new TokenAuthenticator($this->identifiers, [
             'queryParam' => 'token',
         ]);
-        $result = $tokenAuth->authenticate($requestWithParams, $this->response);
+        $result = $tokenAuth->authenticate($requestWithParams);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
     }
@@ -121,7 +118,7 @@ class TokenAuthenticatorTest extends TestCase
             'header' => 'Token',
             'tokenPrefix' => 'identity',
         ]);
-        $result = $tokenAuth->authenticate($requestWithHeaders, $this->response);
+        $result = $tokenAuth->authenticate($requestWithHeaders);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
 
@@ -131,7 +128,7 @@ class TokenAuthenticatorTest extends TestCase
             'header' => 'Token',
             'tokenPrefix' => 'identity',
         ]);
-        $result = $tokenAuth->authenticate($requestWithHeaders, $this->response);
+        $result = $tokenAuth->authenticate($requestWithHeaders);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
     }
@@ -147,7 +144,7 @@ class TokenAuthenticatorTest extends TestCase
             'header' => 'Token',
         ]);
 
-        $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals(), $this->response);
+        $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals());
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }
@@ -163,7 +160,7 @@ class TokenAuthenticatorTest extends TestCase
             'queryParam' => 'token',
         ]);
 
-        $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals(), $this->response);
+        $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals());
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }
@@ -177,7 +174,7 @@ class TokenAuthenticatorTest extends TestCase
     {
         $tokenAuth = new TokenAuthenticator($this->identifiers);
 
-        $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals(), $this->response);
+        $result = $tokenAuth->authenticate(ServerRequestFactory::fromGlobals());
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }


### PR DESCRIPTION
Currently `AbstractAuthenticator::authenticate()` takes only `ServerRequestInterface` as an argument. There was a point in the test code where `ResponseInterface ` was passed as the second argument, so it has been fixed.

https://github.com/cakephp/authentication/blob/master/src/Authenticator/AbstractAuthenticator.php#L88