### PR TITLE
2.x - Improve login URL mismatch error message.

### DIFF
--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -89,10 +89,17 @@ class FormAuthenticator extends AbstractAuthenticator
             $uri = $uri->withPath((string)$base . $uri->getPath());
         }
 
+        $checkFullUrl = $this->getConfig('urlChecker.checkFullUrl', false);
+        if ($checkFullUrl) {
+            $uri = (string)$uri;
+        } else {
+            $uri = $uri->getPath();
+        }
+
         $errors = [
             sprintf(
                 'Login URL `%s` did not match `%s`.',
-                (string)$uri,
+                $uri,
                 implode('` or `', (array)$this->getConfig('loginUrl'))
             ),
         ];

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -136,7 +136,7 @@ class FormAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
-        $this->assertEquals([0 => 'Login URL `http://localhost/users/does-not-match` did not match `/users/login`.'], $result->getErrors());
+        $this->assertEquals([0 => 'Login URL `/users/does-not-match` did not match `/users/login`.'], $result->getErrors());
     }
 
     /**
@@ -167,7 +167,7 @@ class FormAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
-        $this->assertEquals([0 => 'Login URL `http://localhost/users/does-not-match` did not match `/en/users/login` or `/de/users/login`.'], $result->getErrors());
+        $this->assertEquals([0 => 'Login URL `/users/does-not-match` did not match `/en/users/login` or `/de/users/login`.'], $result->getErrors());
     }
 
     /**
@@ -199,7 +199,7 @@ class FormAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
-        $this->assertEquals([0 => 'Login URL `http://localhost/base/users/login` did not match `/users/login`.'], $result->getErrors());
+        $this->assertEquals([0 => 'Login URL `/base/users/login` did not match `/users/login`.'], $result->getErrors());
     }
 
     /**
@@ -391,6 +391,34 @@ class FormAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertEquals([], $result->getErrors());
+    }
+
+    /**
+     * testFullLoginUrlFailureWithoutCheckFullUrlOption
+     *
+     * @return void
+     */
+    public function testFullLoginUrlFailureWithoutCheckFullUrlOption()
+    {
+        $identifiers = new IdentifierCollection([
+            'Authentication.Password',
+        ]);
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/users/login'],
+            [],
+            ['username' => 'mariano', 'password' => 'password']
+        );
+
+        $form = new FormAuthenticator($identifiers, [
+            'loginUrl' => 'http://localhost/users/login',
+        ]);
+
+        $result = $form->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertEquals([0 => 'Login URL `/users/login` did not match `http://localhost/users/login`.'], $result->getErrors());
     }
 
     /**


### PR DESCRIPTION
Only show the full URL in the login URL mismatch error when the URL checker configuration's `checkFullUrl` option is enabled.

Without breaking changes to the URL checker interface, this is the best I could come up with for now. This should make the message generally less ambiguous, and specifically improve a situation where a full URL is used for the `loginUrl` option, but `checkFullUrl` isn't enabled, the check would fail, but the error message would show two identical full URLs.