### PR TITLE
Test passing identity instance to persistIdentity() and setIdentity()

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -297,6 +297,9 @@ class AuthenticationService implements AuthenticationServiceInterface
         }
 
         $identityData = $this->_result->getData();
+        if ($identityData === null) {
+            return null;
+        }
 
         return $this->buildIdentity($identityData);
     }

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -296,12 +296,9 @@ class AuthenticationService implements AuthenticationServiceInterface
             return null;
         }
 
-        $identity = $this->_result->getData();
-        if (!($identity instanceof IdentityInterface)) {
-            $identity = $this->buildIdentity($identity);
-        }
+        $identityData = $this->_result->getData();
 
-        return $identity;
+        return $this->buildIdentity($identityData);
     }
 
     /**
@@ -322,6 +319,10 @@ class AuthenticationService implements AuthenticationServiceInterface
      */
     public function buildIdentity($identityData): IdentityInterface
     {
+        if ($identityData instanceof IdentityInterface) {
+            return $identityData;
+        }
+
         $class = $this->getConfig('identityClass');
 
         if (is_callable($class)) {

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -292,12 +292,12 @@ class AuthenticationService implements AuthenticationServiceInterface
      */
     public function getIdentity(): ?IdentityInterface
     {
-        if ($this->_result === null || !$this->_result->isValid()) {
+        if ($this->_result === null) {
             return null;
         }
 
         $identityData = $this->_result->getData();
-        if ($identityData === null) {
+        if (!$this->_result->isValid() || $identityData === null) {
             return null;
         }
 

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -646,6 +646,29 @@ class AuthenticationServiceTest extends TestCase
         $this->assertSame($identity, $service->getIdentity());
     }
 
+    /**
+     * testGetIdentityNull
+     *
+     * @return void
+     */
+    public function testGetIdentityNull()
+    {
+        $request = new ServerRequest();
+
+        $result = new Result(null, Result::FAILURE_OTHER);
+
+        $authenticator = $this->createMock(AuthenticatorInterface::class);
+        $authenticator->method('authenticate')
+            ->willReturn($result);
+
+        $service = new AuthenticationService();
+        $service->authenticators()->set('Test', $authenticator);
+
+        $service->authenticate($request);
+
+        $this->assertNull($service->getIdentity());
+    }
+
     public function testGetIdentityAttribute()
     {
         $service = new AuthenticationService(['identityAttribute' => 'user']);

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -515,6 +515,25 @@ class AuthenticationServiceTest extends TestCase
     }
 
     /**
+     * Tests that passing the identity instance buildIdentity() gets the same result
+     *
+     * @return void
+     */
+    public function testBuildIdentityWithInstance()
+    {
+        $service = new AuthenticationService([
+            'identifiers' => [
+                'Authentication.Password',
+            ],
+        ]);
+
+        $identity = new Identity([]);
+        $result = $service->buildIdentity($identity);
+
+        $this->assertSame($result, $identity);
+    }
+
+    /**
      * testBuildIdentityRuntimeException
      *
      * @return void

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -426,7 +426,10 @@ class AuthenticationServiceTest extends TestCase
 
     /**
      * Test that the persistIdentity() called with an identity instance sets
-     * this instance as a request attribute
+     * this instance as a request attribute.
+     *
+     * For example the identity data passed to this method (eg. User entity)
+     * may already implement the IdentityInterface itself.
      *
      * @return void
      */

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -425,6 +425,25 @@ class AuthenticationServiceTest extends TestCase
     }
 
     /**
+     * Test that the persistIdentity() called with an identity instance sets
+     * this instance as a request attribute
+     *
+     * @return void
+     */
+    public function testPersistIdentityInstance()
+    {
+        $request = new ServerRequest();
+        $response = new Response();
+        $identity = new Identity([]);
+
+        $service = new AuthenticationService();
+
+        $result = $service->persistIdentity($request, $response, $identity);
+
+        $this->assertSame($identity, $result['request']->getAttribute('identity'));
+    }
+
+    /**
      * testGetResult
      *
      * @return void

--- a/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
@@ -283,7 +283,7 @@ DIGEST;
         } catch (AuthenticationRequiredException $e) {
             $this->assertSame(401, $e->getCode());
             $header = $e->getHeaders()['WWW-Authenticate'];
-            $this->assertRegexp(
+            $this->assertMatchesRegularExpression(
                 '/^Digest realm="localhost",qop="auth",nonce="[A-Za-z0-9=]+",opaque="123abc"$/',
                 $header
             );
@@ -326,7 +326,7 @@ DIGEST;
         } catch (AuthenticationRequiredException $e) {
             $this->assertSame(401, $e->getCode());
             $header = $e->getHeaders()['WWW-Authenticate'];
-            $this->assertRegexp(
+            $this->assertMatchesRegularExpression(
                 '/^Digest realm="localhost",qop="auth",nonce="[A-Za-z0-9=]+",opaque="123abc"$/',
                 $header
             );

--- a/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
@@ -26,6 +26,7 @@ use Cake\Http\ServerRequestFactory;
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Constraint\RegularExpression;
 
 /**
  * Test case for HttpDigestAuthentication
@@ -514,5 +515,20 @@ DIGEST;
         $nonceValue = $expiryTime . ':' . $signatureValue;
 
         return base64_encode($nonceValue);
+    }
+
+    /**
+     * Asserts that a string matches a given regular expression.
+     *
+     * @param string $pattern Regex pattern
+     * @param string $string String to test
+     * @param string $message Message
+     * @return void
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @codeCoverageIgnore
+     */
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        static::assertThat($string, new RegularExpression($pattern), $message);
     }
 }

--- a/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
@@ -176,7 +176,7 @@ class JwtAuthenticatorTest extends TestCase
             ])
             ->getMock();
 
-        $authenticator->expects($this->at(0))
+        $authenticator->expects($this->once())
             ->method('getPayLoad')
             ->willThrowException(new Exception());
 
@@ -207,7 +207,7 @@ class JwtAuthenticatorTest extends TestCase
             ])
             ->getMock();
 
-        $authenticator->expects($this->at(0))
+        $authenticator->expects($this->once())
             ->method('getPayLoad')
             ->will($this->returnValue(new \stdClass()));
 

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -64,11 +64,11 @@ class SessionAuthenticatorTest extends TestCase
      *
      * @return void
      */
-    public function testAuthenticate()
+    public function testAuthenticateSuccess()
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
 
-        $this->sessionMock->expects($this->at(0))
+        $this->sessionMock->expects($this->once())
             ->method('read')
             ->with('Auth')
             ->will($this->returnValue([
@@ -83,8 +83,18 @@ class SessionAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
+    }
 
-        $this->sessionMock->expects($this->at(0))
+    /**
+     * Test authentication
+     *
+     * @return void
+     */
+    public function testAuthenticateFailure()
+    {
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+
+        $this->sessionMock->expects($this->once())
             ->method('read')
             ->with('Auth')
             ->will($this->returnValue(null));
@@ -99,15 +109,15 @@ class SessionAuthenticatorTest extends TestCase
     }
 
     /**
-     * Test session data verification by database lookup
+     * Test successful session data verification by database lookup
      *
      * @return void
      */
-    public function testVerifyByDatabase()
+    public function testVerifyByDatabaseSuccess()
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
 
-        $this->sessionMock->expects($this->at(0))
+        $this->sessionMock->expects($this->once())
             ->method('read')
             ->with('Auth')
             ->will($this->returnValue([
@@ -124,8 +134,18 @@ class SessionAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
+    }
 
-        $this->sessionMock->expects($this->at(0))
+    /**
+     * Test session data verification by database lookup failure
+     *
+     * @return void
+     */
+    public function testVerifyByDatabaseFailure()
+    {
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+
+        $this->sessionMock->expects($this->once())
             ->method('read')
             ->with('Auth')
             ->will($this->returnValue([
@@ -159,10 +179,10 @@ class SessionAuthenticatorTest extends TestCase
         $data = new ArrayObject(['username' => 'florian']);
 
         $this->sessionMock
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('check')
-            ->with('Auth')
-            ->willReturn(false);
+            ->withConsecutive(['Auth'], ['Auth'])
+            ->willReturnOnConsecutiveCalls(false, true);
 
         $this->sessionMock
             ->expects($this->once())
@@ -172,12 +192,6 @@ class SessionAuthenticatorTest extends TestCase
             ->expects($this->once())
             ->method('write')
             ->with('Auth', $data);
-
-        $this->sessionMock
-            ->expects($this->at(3))
-            ->method('check')
-            ->with('Auth')
-            ->willReturn(true);
 
         $result = $authenticator->persistIdentity($request, $response, $data);
         $this->assertIsArray($result);
@@ -203,12 +217,12 @@ class SessionAuthenticatorTest extends TestCase
 
         $authenticator = new SessionAuthenticator($this->identifiers);
 
-        $this->sessionMock->expects($this->at(0))
+        $this->sessionMock->expects($this->once())
             ->method('delete')
             ->with('Auth');
 
         $this->sessionMock
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('renew');
 
         $result = $authenticator->clearIdentity($request, $response);

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -203,6 +203,26 @@ class AuthenticationComponentTest extends TestCase
     }
 
     /**
+     * Test that the setIdentity() called with an identity instance sets
+     * this instance as a request attribute
+     *
+     * @eturn void
+     */
+    public function testSetIdentityInstance()
+    {
+        $request = $this->request->withAttribute('authentication', $this->service);
+
+        $controller = new Controller($request, $this->response);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $identity = new Identity($this->identityData);
+        $component->setIdentity($identity);
+        $result = $component->getIdentity();
+        $this->assertSame($identity, $result);
+    }
+
+    /**
      * Ensure setIdentity() clears identity and persists identity data.
      *
      * @eturn void


### PR DESCRIPTION
This adds missing tests for calling persistIdentity() and setIdentity() with identity instance.

Refs #448

PS. I've also removed deprecated method calls form tests.