### PR TITLE
Clarify queryParam documentation for unauthenticated redirects

### DIFF
--- a/docs/en/middleware.rst
+++ b/docs/en/middleware.rst
@@ -22,8 +22,9 @@ On the service you can use the following configuration options:
 - ``identityAttribute`` - The request attribute used to store the identity.
   Default to ``identity``.
 - ``unauthenticatedRedirect`` - The URL to redirect unauthenticated errors to.
-- ``queryParam`` - Set to a string to have unauthenticated redirects contain
-  a ``redirect`` query string parameter with the previously blocked URL.
+- ``queryParam`` - The name of the query string parameter containing the
+  previously blocked URL in case of unauthenticated redirect, or null to disable
+  appending the denied URL. Defaults to ``null``.
 
 
 Configuring Multiple Authentication Setups

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -76,8 +76,8 @@ class AuthenticationService implements AuthenticationServiceInterface
      * - `identityAttribute` - The request attribute used to store the identity. Default to `identity`.
      * - `unauthenticatedRedirect` - The URL to redirect unauthenticated errors to. See
      *    AuthenticationComponent::allowUnauthenticated()
-     * - `queryParam` - Set to a string to have unauthenticated redirects contain a `redirect` query string
-     *   parameter with the previously blocked URL.
+     * - `queryParam` - The name of the query string parameter containing the previously blocked URL
+     *   in case of unauthenticated redirect, or null to disable appending the denied URL.
      *
      * ### Example:
      *

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -48,8 +48,8 @@ class AuthenticationMiddleware implements MiddlewareInterface
      * - `identityAttribute` - The request attribute to store the identity in.
      * - `unauthenticatedRedirect` - The URL to redirect unauthenticated errors to. See
      *    AuthenticationComponent::allowUnauthenticated()
-     * - `queryParam` - Set to true to have unauthenticated redirects contain a `redirect` query string
-     *   parameter with the previously blocked URL.
+     * - `queryParam` - The name of the query string parameter containing the previously blocked
+     *   URL in case of unauthenticated redirect, or null to disable appending the denied URL.
      *
      * @var array
      */


### PR DESCRIPTION
queryParam is used for unauthenticated redirects in AuthenticationMiddelware and forwarded to AuthenticationService, but the API doc is unclear and inconsistent about it.

While this config option is actually expected to be the parameter name of denied URL in redirect query string, AuthenticationService documents it as "_Set to a string_ (which string ?) _to have unauthenticated redirects containing a `redirect`query string parameter_ (which seems to mean that the parameter name is always "redirect") _with the previously blocked URL_". This description was reported in middleware doc as well.

Moreover, AuthenticationMiddleware documents it as "_**Set to true** to have_..." and so on. In fact, setting it to true would result in having a query string parameter named "true", which is irrelevant.