### PR TITLE
Added the default option to add the application salt to the cookie

### DIFF
--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -263,6 +263,7 @@ Configuration options:
    ``null`` and all pages will be checked.
 -  **passwordHasher**: Password hasher to use for token hashing. Default
    is ``DefaultPasswordHasher::class``.
+-  **salt**: When ``true``, the application's Security salt will be appended to the token before hashing. When ``false``, no salt is used. When a string is passed this will be used as a salt instead. Default is ``true``.
 
 Usage
 -----

--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -263,7 +263,10 @@ Configuration options:
    ``null`` and all pages will be checked.
 -  **passwordHasher**: Password hasher to use for token hashing. Default
    is ``DefaultPasswordHasher::class``.
--  **salt**: When ``true``, the application's Security salt will be appended to the token before hashing. When ``false``, no salt is used. When a string is passed this will be used as a salt instead. Default is ``true``.
+-  **salt**: When ``false`` no salt is used. When a string is passed that value is used as a salt value. 
+   When ``true`` the default Security.salt is used. Default is ``true``. When a salt is used, the cookie value 
+   will contain `hash(username + password + hmac(username + password, salt))`. This helps harden tokens against possible 
+   database leaks and enables cookie values to be invalidated by rotating the salt value.
 
 Usage
 -----

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -22,6 +22,8 @@ use Authentication\PasswordHasher\PasswordHasherTrait;
 use Authentication\UrlChecker\UrlCheckerTrait;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieInterface;
+use Cake\Utility\Security;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -51,6 +53,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
             'name' => 'CookieAuth',
         ],
         'passwordHasher' => 'Authentication.Default',
+        'salt' => true,
     ];
 
     /**
@@ -144,7 +147,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
     /**
      * Creates a plain part of a cookie token.
      *
-     * Returns concatenated username and password hash.
+     * Returns concatenated username, password hash, and HMAC signature.
      *
      * @param array|\ArrayAccess $identity Identity data.
      * @return string
@@ -154,7 +157,23 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
         $usernameField = $this->getConfig('fields.username');
         $passwordField = $this->getConfig('fields.password');
 
-        return $identity[$usernameField] . $identity[$passwordField];
+        $salt = $this->getConfig('salt', '');
+
+        $value = $identity[$usernameField] . $identity[$passwordField];
+
+        if ($salt === false) {
+            return $value;
+        }
+        if ($salt === true) {
+            $salt = Security::getSalt();
+        } elseif (!is_string($salt) || $salt === '') {
+            throw new InvalidArgumentException('Salt must be a non-empty string.');
+        }
+
+        $hmac = hash_hmac('sha1', $value, $salt);
+        // Instead of appending the plain salt, we create a hash. This limits the chance of the salt being leaked.
+
+        return $value . $hmac;
     }
 
     /**

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -19,10 +19,12 @@ use ArrayObject;
 use Authentication\Authenticator\CookieAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
+use Cake\Core\Configure;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -45,6 +47,8 @@ class CookieAuthenticatorTest extends TestCase
     {
         $this->skipIf(!class_exists(Cookie::class));
 
+        // Note: security salt is written in tests/bootstrap.php
+
         parent::setUp();
     }
 
@@ -64,7 +68,7 @@ class CookieAuthenticatorTest extends TestCase
             null,
             null,
             [
-                'CookieAuth' => '["$2y$10$1bE1SgasKoz9WmEvUfuZLeYa6pQgxUIJ5LAoS/KGmC1hNuWkUG7ES"]',
+                'CookieAuth' => '["$2y$10$O5VgLDfIqszzr0Q47Ygkc.LkoLIwlIjc/OzoGp6yJasQlxcHU4.ES"]',
             ]
         );
 
@@ -91,7 +95,8 @@ class CookieAuthenticatorTest extends TestCase
             null,
             null,
             [
-                'CookieAuth' => '["mariano","$2y$10$1bE1SgasKoz9WmEvUfuZLeYa6pQgxUIJ5LAoS/KGmC1hNuWkUG7ES"]',
+                // hash(username . password . hmac(username . password, salt)
+                'CookieAuth' => '["mariano","$2y$10$RlCAFt3e/9l42f8SIaIbqejOg9/b/HklPo.fjXY.tFGuluafugssa"]',
             ]
         );
 
@@ -118,7 +123,7 @@ class CookieAuthenticatorTest extends TestCase
             null,
             null,
             [
-                'CookieAuth' => ['mariano', '$2y$10$1bE1SgasKoz9WmEvUfuZLeYa6pQgxUIJ5LAoS/KGmC1hNuWkUG7ES'],
+                'CookieAuth' => ['mariano', '$2y$10$RlCAFt3e/9l42f8SIaIbqejOg9/b/HklPo.fjXY.tFGuluafugssa'],
             ]
         );
 
@@ -127,6 +132,62 @@ class CookieAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
+    }
+
+    /**
+     * testAuthenticateSuccessNoSalt
+     *
+     * @return void
+     */
+    public function testAuthenticateNoSalt()
+    {
+        Configure::delete('Security.salt');
+
+        $identifiers = new IdentifierCollection([
+            'Authentication.Password',
+        ]);
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/testpath'],
+            null,
+            null,
+            [
+                // hash(username . password)
+                'CookieAuth' => '["mariano","$2y$10$yq91zLgrlF0TUzPjFj49DOL44svGrOYxaBfB6QYWEvxVKzNkvcVom"]',
+            ]
+        );
+
+        $authenticator = new CookieAuthenticator($identifiers, ['salt' => false]);
+        $result = $authenticator->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
+    }
+
+    /**
+     * testAuthenticateSuccessNoSalt
+     *
+     * @return void
+     */
+    public function testAuthenticateInvalidSalt()
+    {
+        $identifiers = new IdentifierCollection([
+            'Authentication.Password',
+        ]);
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/testpath'],
+            null,
+            null,
+            [
+                'CookieAuth' => '["mariano","some_hash"]',
+            ]
+        );
+
+        $authenticator = new CookieAuthenticator($identifiers, ['salt' => '']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $authenticator->authenticate($request);
     }
 
     /**
@@ -241,7 +302,7 @@ class CookieAuthenticatorTest extends TestCase
         $this->assertInstanceOf(RequestInterface::class, $result['request']);
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
         $this->assertStringContainsString(
-            'CookieAuth=%5B%22mariano%22%2C%22%242y%2410%24',
+            'CookieAuth=%5B%22mariano%22%2C%22%242y%2410%24', // `CookieAuth=["mariano","$2y$10$`
             $result['response']->getHeaderLine('Set-Cookie')
         );
         $this->assertStringContainsString(

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -95,7 +95,7 @@ class CookieAuthenticatorTest extends TestCase
             null,
             null,
             [
-                // hash(username . password . hmac(username . password, salt)
+                // hash(username . password . hmac(username . password, salt))
                 'CookieAuth' => '["mariano","$2y$10$RlCAFt3e/9l42f8SIaIbqejOg9/b/HklPo.fjXY.tFGuluafugssa"]',
             ]
         );


### PR DESCRIPTION
…defending against spoofs after e.g. a database leak. Now an attacker would need both the database and the filesystem in order to spoof someones session.

Fixes #439 (or partly at least)