### PR TITLE
Docs: mention compatibility with cakephp4

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -8,6 +8,8 @@ Project's ROOT directory (where the **composer.json** file is located)
 
     php composer.phar require "cakephp/authentication:^2.0"
 
+Version 2 of the Authentication Plugin is compatible with CakePHP 4.
+
 Load the plugin by adding the following statement in your project's ``src/Application.php``::
 
     public function bootstrap(): void


### PR DESCRIPTION
It seems like sometimes people think authentication version 2 is only compatible with CakePHP 2.
I will also create a PR for authorization plugin as well.