### PR TITLE
Allow skipping the challenge exception generation for Http Basic/Digest Auth.

### DIFF
--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -209,7 +209,7 @@ See https://en.wikipedia.org/wiki/Basic_access_authentication
 
 .. note::
 
-    This authenticator will halt the request when authentication credentials are missing or invalid. 
+    This authenticator will halt the request when authentication credentials are missing or invalid.
 
 Configuration options:
 
@@ -223,7 +223,7 @@ See https://en.wikipedia.org/wiki/Digest_access_authentication
 
 .. note::
 
-    This authenticator will halt the request when authentication credentials are missing or invalid. 
+    This authenticator will halt the request when authentication credentials are missing or invalid.
 
 Configuration options:
 
@@ -399,7 +399,7 @@ You can also get the identifier that identified the user as well::
 Using Stateless Authenticators with Stateful Authenticators
 ===========================================================
 
-When using ``Token`` or ``HttpBasic``, ``HttpDigest`` with other authenticators,
+When using ``HttpBasic``, ``HttpDigest`` with other authenticators,
 you should remember that these authenticators will halt the request when
 authentication credentials are missing or invalid. This is necessary as these
 authenticators must send specific challenge headers in the response::

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -34,39 +34,24 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
      */
     public function authenticate(ServerRequestInterface $request): ResultInterface
     {
-        $user = $this->getUser($request);
+        $server = $request->getServerParams();
+        $username = $server['PHP_AUTH_USER'] ?? '';
+        $password = $server['PHP_AUTH_PW'] ?? '';
 
-        if (empty($user)) {
+        if ($username === '' || $password === '') {
             return new Result(null, Result::FAILURE_CREDENTIALS_MISSING);
         }
 
-        return new Result($user, Result::SUCCESS);
-    }
-
-    /**
-     * Get a user based on information in the request. Used by cookie-less auth for stateless clients.
-     *
-     * @param \Psr\Http\Message\ServerRequestInterface $request Request object.
-     * @return \ArrayAccess|array|null User entity or null on failure.
-     */
-    public function getUser(ServerRequestInterface $request)
-    {
-        $server = $request->getServerParams();
-        if (!isset($server['PHP_AUTH_USER']) || !isset($server['PHP_AUTH_PW'])) {
-            return null;
-        }
-
-        $username = $server['PHP_AUTH_USER'];
-        $password = $server['PHP_AUTH_PW'];
-
-        if (!is_string($username) || $username === '' || !is_string($password) || $password === '') {
-            return null;
-        }
-
-        return $this->_identifier->identify([
+        $user = $this->_identifier->identify([
             IdentifierInterface::CREDENTIAL_USERNAME => $username,
             IdentifierInterface::CREDENTIAL_PASSWORD => $password,
         ]);
+
+        if ($user === null) {
+            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
+        }
+
+        return new Result($user, Result::SUCCESS);
     }
 
     /**

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -26,6 +26,22 @@ use Psr\Http\Message\ServerRequestInterface;
 class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessInterface
 {
     /**
+     * Default config for this object.
+     * - `fields` The fields to use to identify a user by.
+     * - `skipChallenge` If set to `true` then challenge exception will not be
+     *   generated in case of authentication failure. Defaults to `false`.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'fields' => [
+            IdentifierInterface::CREDENTIAL_USERNAME => 'username',
+            IdentifierInterface::CREDENTIAL_PASSWORD => 'password',
+        ],
+        'skipChallenge' => false,
+    ];
+
+    /**
      * Authenticate a user using HTTP auth. Will use the configured User model and attempt a
      * login using HTTP auth.
      *
@@ -63,6 +79,10 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
      */
     public function unauthorizedChallenge(ServerRequestInterface $request): void
     {
+        if ($this->getConfig('skipChallenge')) {
+            return;
+        }
+
         throw new AuthenticationRequiredException($this->loginHeaders($request), '');
     }
 

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -105,6 +105,35 @@ class AuthenticationServiceTest extends TestCase
     }
 
     /**
+     * Test that no exception if thrown when challenge is disabled for authenticator
+     *
+     * @return void
+     */
+    public function testAuthenticateWithChallengeDisabled()
+    {
+        $request = ServerRequestFactory::fromGlobals([
+            'SERVER_NAME' => 'example.com',
+            'REQUEST_URI' => '/testpath',
+            'PHP_AUTH_USER' => 'admad',
+            'PHP_AUTH_PW' => 'WRONG',
+        ]);
+
+        $service = new AuthenticationService([
+            'identifiers' => [
+                'Authentication.Password',
+            ],
+            'authenticators' => [
+                'Authentication.HttpBasic' => [
+                    'skipChallenge' => true,
+                ],
+            ],
+        ]);
+
+        $result = $service->authenticate($request);
+        $this->assertFalse($result->isValid());
+    }
+
+    /**
      * testLoadAuthenticatorException
      */
     public function testLoadAuthenticatorException()

--- a/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
@@ -18,6 +18,7 @@ namespace Authentication\Test\TestCase\Authenticator;
 
 use Authentication\Authenticator\AuthenticationRequiredException;
 use Authentication\Authenticator\HttpBasicAuthenticator;
+use Authentication\Authenticator\ResultInterface;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\ServerRequestFactory;
@@ -84,6 +85,7 @@ class HttpBasicAuthenticatorTest extends TestCase
 
         $result = $this->auth->authenticate($request);
         $this->assertFalse($result->isValid());
+        $this->assertSame(ResultInterface::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }
 
     /**
@@ -102,6 +104,7 @@ class HttpBasicAuthenticatorTest extends TestCase
 
         $result = $this->auth->authenticate($request);
         $this->assertFalse($result->isValid());
+        $this->assertSame(ResultInterface::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }
 
     /**
@@ -120,6 +123,7 @@ class HttpBasicAuthenticatorTest extends TestCase
 
         $result = $this->auth->authenticate($request);
         $this->assertFalse($result->isValid());
+        $this->assertSame(ResultInterface::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
     }
 
     /**
@@ -139,6 +143,7 @@ class HttpBasicAuthenticatorTest extends TestCase
 
         $result = $this->auth->authenticate($request);
         $this->assertFalse($result->isValid());
+        $this->assertSame(ResultInterface::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
     }
 
     /**


### PR DESCRIPTION
Also updated HttpBasicAuthenticator to set proper result status
depending on whether credentials are missing or identity is not found.

Refs #497.