### PR TITLE
Bump firebase/php-jwt to v5.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "cakephp/cakephp": "^4.0",
         "cakephp/cakephp-codesniffer": "^4.0",
-        "firebase/php-jwt": "^5.0",
+        "firebase/php-jwt": "^5.5",
         "phpunit/phpunit": "^8.5 || ^9.3"
     },
     "suggest": {

--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -102,13 +102,16 @@ example.
 -  **queryParam**: The query param to check for the token. The default
    is ``token``.
 -  **tokenPrefix**: The token prefix. Default is ``bearer``.
--  **algorithms**: An array of hashing algorithms for Firebase JWT.
-   Default is an array ``['HS256']``.
+-  **algorithm**: The hashing algorithm for Firebase JWT.
+   Default is ``'HS256'``.
 -  **returnPayload**: To return or not return the token payload directly
    without going through the identifiers. Default is ``true``.
 -  **secretKey**: Default is ``null`` but you’re **required** to pass a
    secret key if you’re not in the context of a CakePHP application that
    provides it through ``Security::salt()``.
+
+You need to add the lib `firebase/php-jwt <https://github.com/firebase/php-jwt>`_
+v5.5 or above to your app to use the ``JwtAuthenticator``.
 
 By default the ``JwtAuthenticator`` uses ``HS256`` symmetric key algorithm and uses
 the value of ``Cake\Utility\Security::salt()`` as encryption key.
@@ -137,7 +140,7 @@ Add the following to your ``Application`` class::
         $service->loadIdentifier('Authentication.JwtSubject');
         $service->loadAuthenticator('Authentication.Jwt', [
             'secretKey' => file_get_contents(CONFIG . '/jwt.pem'),
-            'algorithms' => ['RS256'],
+            'algorithm' => 'RS256',
             'returnPayload' => false
         ]);
     }
@@ -209,7 +212,7 @@ See https://en.wikipedia.org/wiki/Basic_access_authentication
 
 .. note::
 
-    This authenticator will halt the request when authentication credentials are missing or invalid. 
+    This authenticator will halt the request when authentication credentials are missing or invalid.
 
 Configuration options:
 
@@ -223,7 +226,7 @@ See https://en.wikipedia.org/wiki/Digest_access_authentication
 
 .. note::
 
-    This authenticator will halt the request when authentication credentials are missing or invalid. 
+    This authenticator will halt the request when authentication credentials are missing or invalid.
 
 Configuration options:
 

--- a/src/Authenticator/JwtAuthenticator.php
+++ b/src/Authenticator/JwtAuthenticator.php
@@ -21,6 +21,7 @@ use Authentication\Identifier\IdentifierInterface;
 use Cake\Utility\Security;
 use Exception;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use stdClass;
@@ -34,7 +35,7 @@ class JwtAuthenticator extends TokenAuthenticator
         'header' => 'Authorization',
         'queryParam' => 'token',
         'tokenPrefix' => 'bearer',
-        'algorithms' => ['HS256'],
+        'algorithm' => 'HS256',
         'returnPayload' => true,
         'secretKey' => null,
         'subjectKey' => IdentifierInterface::CREDENTIAL_JWT_SUBJECT,
@@ -59,6 +60,14 @@ class JwtAuthenticator extends TokenAuthenticator
                 throw new RuntimeException('You must set the `secretKey` config key for JWT authentication.');
             }
             $this->setConfig('secretKey', \Cake\Utility\Security::getSalt());
+        }
+
+        if (isset($config['algorithms'])) {
+            deprecationWarning(
+                'The `algorithms` array config is deprecated, use the `algorithm` string config instead.'
+                . ' This is due to the new recommended usage of `firebase/php-jwt`.'
+                . 'See https://github.com/firebase/php-jwt/releases/tag/v5.5.0'
+            );
         }
     }
 
@@ -144,10 +153,17 @@ class JwtAuthenticator extends TokenAuthenticator
      */
     protected function decodeToken(string $token): ?object
     {
-        return JWT::decode(
-            $token,
-            $this->getConfig('secretKey'),
-            $this->getConfig('algorithms')
-        );
+        $algorithms = $this->getConfig('algorithms');
+        if ($algorithms) {
+            return JWT::decode(
+                $token,
+                $this->getConfig('secretKey'),
+                $algorithms
+            );
+        }
+
+        $key = new Key($this->getConfig('secretKey'), $this->getConfig('algorithm'));
+
+        return JWT::decode($token, $key);
     }
 }

--- a/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
@@ -94,6 +94,25 @@ class JwtAuthenticatorTest extends TestCase
     }
 
     /**
+     * @deprecated
+     */
+    public function testUsingDeprecatedConfig()
+    {
+        $this->request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/']
+        );
+        $this->request = $this->request->withAddedHeader('Authorization', 'Bearer ' . $this->token);
+
+        $this->deprecated(function() {
+            $authenticator = new JwtAuthenticator($this->identifiers, [
+                'secretKey' => 'secretKey',
+                'subjectKey' => 'subjectId',
+                'algorithms' => ['HS256'],
+            ]);
+        });
+    }
+
+    /**
      * testAuthenticateViaQueryParamToken
      *
      * @return void

--- a/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
@@ -103,7 +103,7 @@ class JwtAuthenticatorTest extends TestCase
         );
         $this->request = $this->request->withAddedHeader('Authorization', 'Bearer ' . $this->token);
 
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $authenticator = new JwtAuthenticator($this->identifiers, [
                 'secretKey' => 'secretKey',
                 'subjectKey' => 'subjectId',


### PR DESCRIPTION
Update JwtAutenticator to use the new "algorithm" config and deprecate "algorithms" config.

Refs https://github.com/firebase/php-jwt/releases/tag/v5.5.0

This will be the start of the next minor release for authentication. Before this is merged we should do a bugfix release to address how configuration is merged.