### PR TITLE
User friendly exception when auth middleware is not loaded

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -139,7 +139,10 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
         $controller = $this->getController();
         $service = $controller->getRequest()->getAttribute('authentication');
         if ($service === null) {
-            throw new Exception('The request object does not contain the required `authentication` attribute');
+            throw new Exception(
+                'The request object does not contain the required `authentication` attribute. Verify the ' .
+                'AuthenticationMiddleware has been added.'
+            );
         }
 
         if (!($service instanceof AuthenticationServiceInterface)) {


### PR DESCRIPTION
Improves exception message when using the AuthenticationComponent without the required AuthenticationMiddleware.