### PR TITLE
Add note on Authentication.Password Identifier resolvers default finder

### DIFF
--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -14,7 +14,7 @@ using the Password Identifier looks like::
        'resolver' => [
            'className' => 'Authentication.Orm',
            'userModel' => 'Users',
-           'finder' => 'active',
+           'finder' => 'active', // default: 'all'
        ],
        'passwordHasher' => [
            'className' => 'Authentication.Fallback',


### PR DESCRIPTION
Makes it more clear when people copy / paste from the documentation.