### PR TITLE
Support Cached key set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "cakephp/cakephp": "^4.0",
         "cakephp/cakephp-codesniffer": "^4.0",
-        "firebase/php-jwt": "^5.5",
+        "firebase/php-jwt": "^6.2",
         "phpunit/phpunit": "^8.5 || ^9.3"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "cakephp/cakephp": "^4.0",
         "cakephp/cakephp-codesniffer": "^4.0",
         "firebase/php-jwt": "^6.2",
-        "phpunit/phpunit": "^8.5 || ^9.3"
+        "phpunit/phpunit": "^8.5 || ^9.3",
+        "symfony/cache": "^5.4 || ^6.0"
     },
     "suggest": {
         "cakephp/orm": "To use \"OrmResolver\" (Not needed separately if using full CakePHP framework).",

--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -113,7 +113,7 @@ example.
    If provided will be used instead of the secret key.
 
 You need to add the lib `firebase/php-jwt <https://github.com/firebase/php-jwt>`_
-^5.5 to your app to use the ``JwtAuthenticator`` (v6.0 is not currently supported). 
+v6.2 or above to your app to use the ``JwtAuthenticator``.
 
 By default the ``JwtAuthenticator`` uses ``HS256`` symmetric key algorithm and uses
 the value of ``Cake\Utility\Security::salt()`` as encryption key.
@@ -310,9 +310,9 @@ Configuration options:
    ``null`` and all pages will be checked.
 -  **passwordHasher**: Password hasher to use for token hashing. Default
    is ``DefaultPasswordHasher::class``.
--  **salt**: When ``false`` no salt is used. When a string is passed that value is used as a salt value. 
-   When ``true`` the default Security.salt is used. Default is ``true``. When a salt is used, the cookie value 
-   will contain `hash(username + password + hmac(username + password, salt))`. This helps harden tokens against possible 
+-  **salt**: When ``false`` no salt is used. When a string is passed that value is used as a salt value.
+   When ``true`` the default Security.salt is used. Default is ``true``. When a salt is used, the cookie value
+   will contain `hash(username + password + hmac(username + password, salt))`. This helps harden tokens against possible
    database leaks and enables cookie values to be invalidated by rotating the salt value.
 
 Usage

--- a/docs/es/authenticators.rst
+++ b/docs/es/authenticators.rst
@@ -102,8 +102,7 @@ ejemplo.
 -  **queryParam**: Parámetro de la query para verificar el token. Por defecto
    es ``token``.
 -  **tokenPrefix**: Prefijo del token. Por defecto es ``bearer``.
--  **algorithms**: Array de algoritmos hashing para Firebase JWT.
-   El array por defecto es ``['HS256']``.
+-  **algorithm**: El algoritmo de hash para Firebase JWT. Por defecto es ``'HS256'``.
 -  **returnPayload**: Retornar o no el payload del token directamente
    sin pasar a través de los identificadores. Por defecto es ``true``.
 -  **secretKey**: Por defecto es ``null`` pero será **requerido** pasar una
@@ -137,7 +136,7 @@ Agregue lo siguiente a su clase ``Application``::
         $service->loadIdentifier('Authentication.JwtSubject');
         $service->loadAuthenticator('Authentication.Jwt', [
             'secretKey' => file_get_contents(CONFIG . '/jwt.pem'),
-            'algorithms' => ['RS256'],
+            'algorithm' => 'RS256',
             'returnPayload' => false
         ]);
     }

--- a/docs/fr/authenticators.rst
+++ b/docs/fr/authenticators.rst
@@ -110,8 +110,8 @@ source de données, par exemple.
    d'accès. La valeur par défaut est ``token``.
 -  **tokenPrefix**: Le préfixe du jeton d'accès. La valeur par défaut est
    ``bearer``.
--  **algorithms**: L'algorithme de hachage pour Firebase JWT. La valeur par
-   défaut est ``['HS256']``.
+-  **algorithm**: L'algorithme de hachage pour Firebase JWT. La valeur par défaut
+   est ``'HS256'``.
 -  **returnPayload**: Renvoyer ou non la payload du jeton d'accès directement
    sans passer par les identificateurs. La valeur par défaut est ``true``.
 -  **secretKey**: La valeur par défaut est ``null`` mais vous **devez
@@ -122,7 +122,7 @@ source de données, par exemple.
    S'il est fourni, il sera utilisé à la place de ``secret key``.
 
 Pour utiliser le ``JwtAuthenticator``, vous devez ajouter à votre application la
-bibliothèque `firebase/php-jwt <https://github.com/firebase/php-jwt>`__ v5.5 ou
+bibliothèque `firebase/php-jwt <https://github.com/firebase/php-jwt>`__ v6.2 ou
 supérieure.
 
 Par défaut, le ``JwtAuthenticator`` utilise l'algorithme de clé symétrique
@@ -155,7 +155,7 @@ Ajoutez ce qui suit dans votre classe ``Application``::
         $service->loadIdentifier('Authentication.JwtSubject');
         $service->loadAuthenticator('Authentication.Jwt', [
             'secretKey' => file_get_contents(CONFIG . '/jwt.pem'),
-            'algorithms' => 'RS256',
+            'algorithm' => 'RS256',
             'returnPayload' => false
         ]);
     }

--- a/docs/ja/authenticators.rst
+++ b/docs/ja/authenticators.rst
@@ -80,7 +80,7 @@ JWT 認証機能は、ヘッダーまたはクエリパラメータから `JWT t
 -  **header**: トークンを確認するためのヘッダー行です。デフォルトは ``Authorization`` です。
 -  **queryParam**: トークンをチェックするクエリパラメータ。デフォルトは ``token`` です。
 -  **tokenPrefix**: prefixトークン. デフォルトは ``bearer`` です。
--  **algorithms**: Firebase JWT用のハッシュアルゴリズムの配列。デフォルトは配列 ``['HS256']`` です。
+-  **algorithm**: Firebase JWT のハッシュアルゴリズム。デフォルトは ``'HS256'`` です。
 -  **returnPayload**: 識別子を経由せずに、トークンのペイロードを直接返すか返さないか。デフォルトは ``true`` です。
 -  **secretKey**: デフォルトは ``null`` ですが、秘密鍵を ``Security::salt()`` 提供しているCakePHPアプリケーションのコンテキストではない場合は **必須** です。
 
@@ -109,7 +109,7 @@ JWT 認証機能は、ヘッダーまたはクエリパラメータから `JWT t
         $service->loadIdentifier('Authentication.JwtSubject');
         $service->loadAuthenticator('Authentication.Jwt', [
             'secretKey' => file_get_contents(CONFIG . '/jwt.pem'),
-            'algorithms' => ['RS256'],
+            'algorithm' => 'RS256',
             'returnPayload' => false
         ]);
     }

--- a/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
@@ -82,23 +82,6 @@ class JwtAuthenticatorTest extends TestCase
     }
 
     /**
-     * Test that "algorithms" config overwrites the default value instead of merging.
-     *
-     * @deprecated
-     * @return void
-     */
-    public function testAlgorithmsOverwrite()
-    {
-        $this->deprecated(function () {
-            $authenticator = new JwtAuthenticator($this->identifiers, [
-                'algorithms' => ['RS256'],
-            ]);
-
-            $this->assertSame(['RS256'], $authenticator->getConfig('algorithms'));
-        });
-    }
-
-    /**
      * testAuthenticateViaHeaderToken
      *
      * @return void
@@ -119,27 +102,6 @@ class JwtAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
         $this->assertInstanceOf(ArrayAccess::class, $result->getData());
-    }
-
-    /**
-     * @deprecated
-     */
-    public function testUsingDeprecatedConfig()
-    {
-        $this->request = ServerRequestFactory::fromGlobals(
-            ['REQUEST_URI' => '/']
-        );
-        $this->request = $this->request->withAddedHeader('Authorization', 'Bearer ' . $this->tokenHS256);
-
-        $this->deprecated(function () {
-            $authenticator = new JwtAuthenticator($this->identifiers, [
-                'secretKey' => 'secretKey',
-                'subjectKey' => 'subjectId',
-                'algorithms' => ['HS256'],
-            ]);
-            // Appease lowest build
-            $this->assertNotEmpty($authenticator);
-        });
     }
 
     /**


### PR DESCRIPTION
This is meant to gather your thoughts on support for cachedKeySets.

Instead of providing an array with keys to jwks and URL could be passed which is then fetched and cached by php-jwt.
Configuration options still TBD.

This functionality has been added to php-jwt in 6.2: https://github.com/firebase/php-jwt/pull/397

The revelant change would be among these lines: https://github.com/cakephp/authentication/pull/535/files#diff-ace0e7f81ad6600f2a672e7393458f22cc0f8c44e69bd76ef9be077e677c14fbR158