### PR TITLE
2.x - Fix `null` value causing a type error in the password identifier.

### DIFF
--- a/src/Identifier/PasswordIdentifier.php
+++ b/src/Identifier/PasswordIdentifier.php
@@ -128,7 +128,10 @@ class PasswordIdentifier extends AbstractIdentifier
 
         $hasher = $this->getPasswordHasher();
         $hashedPassword = $identity[$passwordField];
-        if (!$hasher->check((string)$password, $hashedPassword)) {
+        if (
+            $hashedPassword === null ||
+            !$hasher->check((string)$password, $hashedPassword)
+        ) {
             return false;
         }
 

--- a/tests/TestCase/Identifier/PasswordIdentifierTest.php
+++ b/tests/TestCase/Identifier/PasswordIdentifierTest.php
@@ -169,6 +169,40 @@ class PasswordIdentifierTest extends TestCase
     }
 
     /**
+     * testIdentifyPasswordAgainstNullValue
+     *
+     * @return void
+     */
+    public function testIdentifyPasswordAgainstNullValue()
+    {
+        $resolver = $this->createMock(ResolverInterface::class);
+        $hasher = $this->createMock(PasswordHasherInterface::class);
+
+        $user = new ArrayObject([
+            'username' => 'mariano',
+            'password' => null,
+        ]);
+
+        $resolver->expects($this->once())
+            ->method('find')
+            ->with(['username' => 'mariano'])
+            ->willReturn($user);
+
+        $hasher->expects($this->never())
+            ->method('check');
+
+        $identifier = new PasswordIdentifier();
+        $identifier->setResolver($resolver)->setPasswordHasher($hasher);
+
+        $result = $identifier->identify([
+            'username' => 'mariano',
+            'password' => 'password',
+        ]);
+
+        $this->assertNull($result);
+    }
+
+    /**
      * testIdentifyEmptyPassword
      *
      * @return void


### PR DESCRIPTION
While maybe considered unusual, and potentially the result of for example misconfiguration, a `NULL` value for the password is generally a valid thing that can exist in the data store, hence it's probably appropriate to fail gracefully.