### PR TITLE
Fix deprecations in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0', '8.1']
+        php-version: ['7.4', '8.0', '8.1']
         db-type: [sqlite]
         prefer-lowest: ['']
         include:
-          - php-version: '7.2'
+          - php-version: '7.4'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.2'
+        php-version: '7.4'
         extensions: mbstring, intl, apcu
         tools: cs2pr
         coverage: none

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "^4.0",
+        "cakephp/cakephp": "^4.4",
         "cakephp/cakephp-codesniffer": "^4.0",
         "firebase/php-jwt": "^5.5",
         "phpunit/phpunit": "^8.5 || ^9.3"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "type": "cakephp-plugin",
     "homepage": "https://cakephp.org",
     "require": {
-        "cakephp/http": "^4.3",
+        "cakephp/http": "^4.4",
         "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
@@ -18,7 +18,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "^4.3",
+        "cakephp/cakephp": "^4.4",
         "cakephp/cakephp-codesniffer": "^4.0",
         "firebase/php-jwt": "^5.5",
         "phpunit/phpunit": "^8.5 || ^9.3"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "type": "cakephp-plugin",
     "homepage": "https://cakephp.org",
     "require": {
-        "cakephp/http": "^4.0",
+        "cakephp/http": "^4.3",
         "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
@@ -18,7 +18,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "^4.4",
+        "cakephp/cakephp": "^4.3",
         "cakephp/cakephp-codesniffer": "^4.0",
         "firebase/php-jwt": "^5.5",
         "phpunit/phpunit": "^8.5 || ^9.3"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,38 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
     bootstrap="./tests/bootstrap.php"
-    >
-    <php>
-        <ini name="memory_limit" value="-1"/>
-    </php>
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <file>src/Identifier/Ldap/ExtensionAdapter.php</file>
+    </exclude>
+  </coverage>
 
-    <!-- Add any additional test suites you want to run here -->
-    <testsuites>
-        <testsuite name="authentication">
-            <directory>tests/TestCase/</directory>
-        </testsuite>
-        <!-- Add plugin test suites here. -->
-    </testsuites>
+  <php>
+    <ini name="memory_limit" value="-1"/>
+    <env name="FIXTURE_SCHEMA_METADATA" value="./vendor/cakephp/cakephp/tests/schema.php"/>
+  </php>
 
-    <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener class="\Cake\TestSuite\Fixture\FixtureInjector">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
-    </listeners>
+  <testsuites>
+    <testsuite name="authentication">
+      <directory>tests/TestCase/</directory>
+    </testsuite>
+  </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <file>src/Identifier/Ldap/ExtensionAdapter.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
-
+  <extensions>
+    <extension class="Cake\TestSuite\Fixture\PHPUnitExtension"/>
+  </extensions>
 </phpunit>

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -30,6 +30,7 @@ use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
+use Cake\Http\Uri;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -746,8 +747,7 @@ class AuthenticationServiceTest extends TestCase
             ['REQUEST_URI' => '/secrets']
         );
         $uri = $request->getUri();
-        $uri->base = '/base';
-        $request = $request->withUri($uri);
+        $request = $request->withUri(new Uri($uri, '/base', $uri->webroot));
 
         $service = new AuthenticationService([
             'unauthenticatedRedirect' => '/users/login',

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -21,6 +21,7 @@ use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\ServerRequestFactory;
+use Cake\Http\Uri;
 use RuntimeException;
 
 class FormAuthenticatorTest extends TestCase
@@ -187,7 +188,7 @@ class FormAuthenticatorTest extends TestCase
             ['username' => 'mariano', 'password' => 'password']
         );
         $uri = $request->getUri();
-        $uri->base = '/base';
+        $uri = new Uri($uri, '/base', $uri->webroot);
         $request = $request->withUri($uri);
         $request = $request->withAttribute('base', $uri->base);
 
@@ -277,8 +278,7 @@ class FormAuthenticatorTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $uri = $request->getUri();
-        $uri->base = '/base';
+        $uri = new Uri($request->getUri(), '/base', '/');
         $request = $request->withUri($uri);
         $request = $request->withAttribute('base', $uri->base);
 

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -26,6 +26,7 @@ use Authentication\Middleware\AuthenticationMiddleware;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
+use Cake\Http\Uri;
 use Firebase\JWT\JWT;
 use TestApp\Application;
 use TestApp\Http\TestRequestHandler;
@@ -592,7 +593,7 @@ class AuthenticationMiddlewareTest extends TestCase
             ['username' => 'mariano', 'password' => 'password']
         );
         $uri = $request->getUri();
-        $uri->base = '/base';
+        $uri = new Uri($uri, '/base', $uri->webroot);
         $request = $request->withUri($uri);
         $handler = new TestRequestHandler(function ($request) {
             throw new UnauthenticatedException();

--- a/tests/TestCase/UrlChecker/DefaultUrlCheckerTest.php
+++ b/tests/TestCase/UrlChecker/DefaultUrlCheckerTest.php
@@ -19,6 +19,7 @@ namespace Authentication\Test\TestCase\UrlChecker;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Authentication\UrlChecker\DefaultUrlChecker;
 use Cake\Http\ServerRequestFactory;
+use Cake\Http\Uri;
 
 /**
  * DefaultUrlCheckerTest
@@ -129,8 +130,7 @@ class DefaultUrlCheckerTest extends TestCase
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/users/login']
         );
-        $uri = $request->getUri();
-        $uri->base = '/base';
+        $uri = new Uri($request->getUri(), '/base', '/base/');
         $request = $request->withUri($uri);
 
         $result = $checker->check($request, 'http://localhost/base/users/login', [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,6 +18,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Routing\Router;
+use Cake\TestSuite\Fixture\SchemaLoader;
 use Cake\Utility\Security;
 
 $findRoot = function ($root) {
@@ -61,3 +62,9 @@ Security::setSalt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
 Plugin::getCollection()->add(new \Authentication\Plugin());
 
 $_SERVER['PHP_SELF'] = '/';
+
+// Create test database schema
+if (env('FIXTURE_SCHEMA_METADATA')) {
+    $loader = new SchemaLoader();
+    $loader->loadInternalFile(env('FIXTURE_SCHEMA_METADATA'));
+}


### PR DESCRIPTION
* Update PHPUnit config for phpunit 9.
* Move to new fixture system.
* Don't mutate the new private properties on Uri.