### PR TITLE
Switch to cake 5 and fix types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ on:
 
 jobs:
   testsuite:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['8.1', '8.2']
         db-type: [sqlite]
         prefer-lowest: ['']
         include:
-          - php-version: '7.4'
+          - php-version: '8.1'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
 
@@ -49,35 +49,35 @@ jobs:
 
     - name: Composer install
       run: |
-        if [[ ${{ matrix.php-version }} == '8.1' ]]; then
-          composer update --ignore-platform-reqs
-        elif ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
+        if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
           composer update --prefer-lowest --prefer-stable
+        elif ${{ matrix.php-version == '8.2' }}; then
+          composer update --ignore-platform-req=php
         else
           composer update
         fi
 
     - name: Setup problem matchers for PHPUnit
-      if: matrix.php-version == '7.4' && matrix.db-type == 'mysql'
+      if: matrix.php-version == '8.1' && matrix.db-type == 'mysql'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Run PHPUnit
       run: |
         if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
 
-        if [[ ${{ matrix.php-version }} == '7.4' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.1' ]]; then
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
         fi
 
     - name: Submit code coverage
-      if: matrix.php-version == '7.4'
+      if: matrix.php-version == '8.1'
       uses: codecov/codecov-action@v3
 
   cs-stan:
     name: Coding Standard & Static Analysis
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
@@ -85,7 +85,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.1'
         extensions: mbstring, intl, apcu
         tools: cs2pr
         coverage: none

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "type": "cakephp-plugin",
     "homepage": "https://cakephp.org",
     "require": {
-        "cakephp/http": "^4.4",
+        "cakephp/http": "5.x-dev",
         "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
@@ -18,10 +18,10 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "^4.4",
-        "cakephp/cakephp-codesniffer": "^4.0",
+        "cakephp/cakephp": "5.x-dev",
+        "cakephp/cakephp-codesniffer": "5.x-dev",
         "firebase/php-jwt": "^6.2",
-        "phpunit/phpunit": "^8.5 || ^9.3"
+        "phpunit/phpunit": "^9.5"
     },
     "suggest": {
         "cakephp/orm": "To use \"OrmResolver\" (Not needed separately if using full CakePHP framework).",

--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -28,7 +28,7 @@ abstract class AbstractCollection extends ObjectRegistry
      *
      * @var array
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * Constructor

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -94,7 +94,7 @@ class AuthenticationService implements AuthenticationServiceInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'authenticators' => [],
         'identifiers' => [],
         'identityClass' => Identity::class,

--- a/src/Authenticator/AbstractAuthenticator.php
+++ b/src/Authenticator/AbstractAuthenticator.php
@@ -30,7 +30,7 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'fields' => [
             IdentifierInterface::CREDENTIAL_USERNAME => 'username',
             IdentifierInterface::CREDENTIAL_PASSWORD => 'password',

--- a/src/Authenticator/AuthenticationRequiredException.php
+++ b/src/Authenticator/AuthenticationRequiredException.php
@@ -29,12 +29,12 @@ class AuthenticationRequiredException extends HttpException
     /**
      * @var array
      */
-    protected $headers = [];
+    protected array $headers = [];
 
     /**
      * @var string
      */
-    protected $body = '';
+    protected string $body = '';
 
     /**
      * Constructor

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -41,7 +41,7 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
     /**
      * @inheritDoc
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'loginUrl' => null,
         'urlChecker' => 'Authentication.Default',
         'rememberMeField' => 'remember_me',

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -234,12 +234,12 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
         unset($options['name']);
 
         if (array_key_exists('expire', $options)) {
-            deprecationWarning('Config key `expire` is deprecated, use `expires` instead.');
+            deprecationWarning('2.x', 'Config key `expire` is deprecated, use `expires` instead.');
             $options['expires'] = $options['expire'];
             unset($options['expire']);
         }
         if (array_key_exists('httpOnly', $options)) {
-            deprecationWarning('Config key `httpOnly` is deprecated, use `httponly` instead.');
+            deprecationWarning('2.x', 'Config key `httpOnly` is deprecated, use `httponly` instead.');
             $options['httponly'] = $options['httpOnly'];
             unset($options['httpOnly']);
         }

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -37,7 +37,7 @@ class FormAuthenticator extends AbstractAuthenticator
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'loginUrl' => null,
         'urlChecker' => 'Authentication.Default',
         'fields' => [

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -33,7 +33,7 @@ class HttpBasicAuthenticator extends AbstractAuthenticator implements StatelessI
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'fields' => [
             IdentifierInterface::CREDENTIAL_USERNAME => 'username',
             IdentifierInterface::CREDENTIAL_PASSWORD => 'password',

--- a/src/Authenticator/JwtAuthenticator.php
+++ b/src/Authenticator/JwtAuthenticator.php
@@ -32,7 +32,7 @@ class JwtAuthenticator extends TokenAuthenticator
     /**
      * @inheritDoc
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'header' => 'Authorization',
         'queryParam' => 'token',
         'tokenPrefix' => 'bearer',

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -34,7 +34,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'fields' => [
             IdentifierInterface::CREDENTIAL_USERNAME => 'username',
         ],

--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -29,7 +29,7 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
     /**
      * @inheritDoc
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'header' => null,
         'queryParam' => null,
         'tokenPrefix' => null,

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -49,7 +49,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'logoutRedirect' => false,
         'requireIdentity' => true,
         'identityAttribute' => 'identity',

--- a/src/Identifier/AbstractIdentifier.php
+++ b/src/Identifier/AbstractIdentifier.php
@@ -27,7 +27,7 @@ abstract class AbstractIdentifier implements IdentifierInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * Errors

--- a/src/Identifier/CallbackIdentifier.php
+++ b/src/Identifier/CallbackIdentifier.php
@@ -31,7 +31,7 @@ class CallbackIdentifier extends AbstractIdentifier
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'callback' => null,
     ];
 

--- a/src/Identifier/JwtSubjectIdentifier.php
+++ b/src/Identifier/JwtSubjectIdentifier.php
@@ -29,7 +29,7 @@ class JwtSubjectIdentifier extends TokenIdentifier
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'tokenField' => 'id',
         'dataField' => self::CREDENTIAL_JWT_SUBJECT,
         'resolver' => 'Authentication.Orm',

--- a/src/Identifier/LdapIdentifier.php
+++ b/src/Identifier/LdapIdentifier.php
@@ -51,7 +51,7 @@ class LdapIdentifier extends AbstractIdentifier
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'ldap' => ExtensionAdapter::class,
         'fields' => [
             self::CREDENTIAL_USERNAME => 'username',

--- a/src/Identifier/PasswordIdentifier.php
+++ b/src/Identifier/PasswordIdentifier.php
@@ -58,7 +58,7 @@ class PasswordIdentifier extends AbstractIdentifier
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'fields' => [
             self::CREDENTIAL_USERNAME => 'username',
             self::CREDENTIAL_PASSWORD => 'password',

--- a/src/Identifier/Resolver/OrmResolver.php
+++ b/src/Identifier/Resolver/OrmResolver.php
@@ -34,7 +34,7 @@ class OrmResolver implements ResolverInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'userModel' => 'Users',
         'finder' => 'all',
     ];

--- a/src/Identifier/TokenIdentifier.php
+++ b/src/Identifier/TokenIdentifier.php
@@ -30,7 +30,7 @@ class TokenIdentifier extends AbstractIdentifier
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'tokenField' => 'token',
         'dataField' => self::CREDENTIAL_TOKEN,
         'resolver' => 'Authentication.Orm',

--- a/src/Identity.php
+++ b/src/Identity.php
@@ -36,7 +36,7 @@ class Identity implements IdentityInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'fieldMap' => [
             'id' => 'id',
         ],

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -53,7 +53,7 @@ class AuthenticationMiddleware implements MiddlewareInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * Authentication service or application instance.

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -69,7 +69,7 @@ class AuthenticationMiddleware implements MiddlewareInterface
      * @param array $config Array of configuration settings.
      * @throws \InvalidArgumentException When invalid subject has been passed.
      */
-    public function __construct($subject, $config = null)
+    public function __construct($subject, $config = [])
     {
         $this->setConfig($config);
 
@@ -169,6 +169,7 @@ class AuthenticationMiddleware implements MiddlewareInterface
             $value = $this->getConfig($key);
             if ($value) {
                 deprecationWarning(
+                    '2.x',
                     "The `{$key}` configuration key on AuthenticationMiddleware is deprecated. " .
                     "Instead set the `{$key}` on your AuthenticationService instance."
                 );

--- a/src/PasswordHasher/AbstractPasswordHasher.php
+++ b/src/PasswordHasher/AbstractPasswordHasher.php
@@ -31,7 +31,7 @@ abstract class AbstractPasswordHasher implements PasswordHasherInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * Constructor

--- a/src/PasswordHasher/DefaultPasswordHasher.php
+++ b/src/PasswordHasher/DefaultPasswordHasher.php
@@ -32,7 +32,7 @@ class DefaultPasswordHasher extends AbstractPasswordHasher
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'hashType' => PASSWORD_DEFAULT,
         'hashOptions' => [],
     ];

--- a/src/PasswordHasher/FallbackPasswordHasher.php
+++ b/src/PasswordHasher/FallbackPasswordHasher.php
@@ -27,7 +27,7 @@ class FallbackPasswordHasher extends AbstractPasswordHasher
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'hashers' => [],
     ];
 

--- a/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/src/PasswordHasher/LegacyPasswordHasher.php
@@ -34,7 +34,7 @@ class LegacyPasswordHasher extends AbstractPasswordHasher
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'hashType' => null,
         'salt' => true,
     ];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -27,19 +27,19 @@ class Plugin extends BasePlugin
      *
      * @var bool
      */
-    protected $bootstrapEnabled = false;
+    protected bool $bootstrapEnabled = false;
 
     /**
      * Load routes or not
      *
      * @var bool
      */
-    protected $routesEnabled = false;
+    protected bool $routesEnabled = false;
 
     /**
      * Console middleware
      *
      * @var bool
      */
-    protected $consoleEnabled = false;
+    protected bool $consoleEnabled = false;
 }

--- a/src/View/Helper/IdentityHelper.php
+++ b/src/View/Helper/IdentityHelper.php
@@ -34,7 +34,7 @@ class IdentityHelper extends Helper
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'identityAttribute' => 'identity',
     ];
 

--- a/tests/TestCase/AuthenticationTestCase.php
+++ b/tests/TestCase/AuthenticationTestCase.php
@@ -26,7 +26,7 @@ class AuthenticationTestCase extends TestCase
      *
      * @var array
      */
-    protected $fixtures = [
+    protected array $fixtures = [
         'core.AuthUsers',
         'core.Users',
     ];

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -35,7 +35,7 @@ class CookieAuthenticatorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected array $fixtures = [
         'core.AuthUsers',
         'core.Users',
     ];

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -31,7 +31,7 @@ class FormAuthenticatorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected array $fixtures = [
         'core.AuthUsers',
         'core.Users',
     ];

--- a/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
@@ -22,7 +22,7 @@ use Authentication\Authenticator\ResultInterface;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\ServerRequestFactory;
-use Cake\I18n\FrozenTime;
+use Cake\I18n\DateTime;
 use Cake\ORM\TableRegistry;
 
 class HttpBasicAuthenticatorTest extends TestCase
@@ -175,8 +175,8 @@ class HttpBasicAuthenticatorTest extends TestCase
         $expected = [
             'id' => 1,
             'username' => '0',
-            'created' => new FrozenTime('2007-03-17 01:16:23'),
-            'updated' => new FrozenTime('2007-03-17 01:18:31'),
+            'created' => new DateTime('2007-03-17 01:16:23'),
+            'updated' => new DateTime('2007-03-17 01:18:31'),
         ];
         $result = $this->auth->authenticate($request);
         $this->assertTrue($result->isValid());
@@ -231,8 +231,8 @@ class HttpBasicAuthenticatorTest extends TestCase
         $expected = [
             'id' => 1,
             'username' => 'mariano',
-            'created' => new FrozenTime('2007-03-17 01:16:23'),
-            'updated' => new FrozenTime('2007-03-17 01:18:31'),
+            'created' => new DateTime('2007-03-17 01:16:23'),
+            'updated' => new DateTime('2007-03-17 01:18:31'),
         ];
 
         $this->assertTrue($result->isValid());

--- a/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpBasicAuthenticatorTest.php
@@ -32,7 +32,7 @@ class HttpBasicAuthenticatorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected array $fixtures = [
         'core.AuthUsers',
         'core.Users',
     ];

--- a/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
@@ -38,7 +38,7 @@ class HttpDigestAuthenticatorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected array $fixtures = [
         'core.AuthUsers',
         'core.Users',
     ];

--- a/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
@@ -23,7 +23,7 @@ use Authentication\Authenticator\Result;
 use Authentication\Authenticator\StatelessInterface;
 use Authentication\Identifier\IdentifierCollection;
 use Cake\Http\ServerRequestFactory;
-use Cake\I18n\FrozenTime;
+use Cake\I18n\DateTime;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Constraint\RegularExpression;
@@ -165,8 +165,8 @@ DIGEST;
         $expected = [
             'id' => 1,
             'username' => 'mariano',
-            'created' => new FrozenTime('2007-03-17 01:16:23'),
-            'updated' => new FrozenTime('2007-03-17 01:18:31'),
+            'created' => new DateTime('2007-03-17 01:16:23'),
+            'updated' => new DateTime('2007-03-17 01:18:31'),
         ];
         $this->assertInstanceOf(Result::class, $result);
         $this->assertTrue($result->isValid());

--- a/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/JwtAuthenticatorTest.php
@@ -33,7 +33,7 @@ class JwtAuthenticatorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected array $fixtures = [
         'core.AuthUsers',
         'core.Users',
     ];

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -33,7 +33,7 @@ class SessionAuthenticatorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected array $fixtures = [
         'core.AuthUsers',
         'core.Users',
     ];

--- a/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
@@ -29,7 +29,7 @@ class TokenAuthenticatorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
+    protected array $fixtures = [
         'core.AuthUsers',
         'core.Users',
     ];

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -28,7 +28,6 @@ use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
-use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\ORM\Entity;
 use TestApp\Authentication\InvalidAuthenticationService;
@@ -92,8 +91,6 @@ class AuthenticationComponentTest extends TestCase
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-
-        $this->response = new Response();
     }
 
     /**
@@ -105,7 +102,7 @@ class AuthenticationComponentTest extends TestCase
     {
         $service = new AuthenticationService();
         $request = $this->request->withAttribute('authentication', $service);
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
         $result = $component->getAuthenticationService();
@@ -121,7 +118,7 @@ class AuthenticationComponentTest extends TestCase
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('The request object does not contain the required `authentication` attribute');
-        $controller = new Controller($this->request, $this->response);
+        $controller = new Controller($this->request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
         $component->getAuthenticationService();
@@ -137,7 +134,7 @@ class AuthenticationComponentTest extends TestCase
         $this->expectException('Exception');
         $this->expectExceptionMessage('Authentication service does not implement Authentication\AuthenticationServiceInterface');
         $request = $this->request->withAttribute('authentication', new InvalidAuthenticationService());
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
         $component->getAuthenticationService();
@@ -154,7 +151,7 @@ class AuthenticationComponentTest extends TestCase
             ->withAttribute('identity', $this->identity)
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -173,7 +170,7 @@ class AuthenticationComponentTest extends TestCase
         $this->request = $this->request->withAttribute('customIdentity', $this->identity);
         $this->request = $this->request->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($this->request, $this->response);
+        $controller = new Controller($this->request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry, [
             'identityAttribute' => 'customIdentity',
@@ -193,7 +190,7 @@ class AuthenticationComponentTest extends TestCase
     {
         $request = $this->request->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -212,7 +209,7 @@ class AuthenticationComponentTest extends TestCase
     {
         $request = $this->request->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -231,7 +228,7 @@ class AuthenticationComponentTest extends TestCase
     {
         $request = $this->request->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -268,7 +265,7 @@ class AuthenticationComponentTest extends TestCase
             ->withAttribute('identity', $this->identity)
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -287,7 +284,7 @@ class AuthenticationComponentTest extends TestCase
         $this->expectExceptionMessage('The identity has not been found.');
         $request = $this->request->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -305,7 +302,7 @@ class AuthenticationComponentTest extends TestCase
             ->withAttribute('identity', $this->identity)
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
         $this->assertNull($component->getResult());
@@ -327,7 +324,7 @@ class AuthenticationComponentTest extends TestCase
             ->withAttribute('identity', $this->identity)
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -351,7 +348,7 @@ class AuthenticationComponentTest extends TestCase
             ->withAttribute('authentication', $this->service)
             ->withQueryParams(['redirect' => 'ok/path?value=key']);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -371,16 +368,13 @@ class AuthenticationComponentTest extends TestCase
             $result = $event;
         });
 
-        $this->service->authenticate(
-            $this->request,
-            $this->response
-        );
+        $this->service->authenticate($this->request);
 
         $request = $this->request
             ->withAttribute('identity', $this->identity)
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $controller->loadComponent('Authentication.Authentication');
         $controller->startupProcess();
 
@@ -403,7 +397,7 @@ class AuthenticationComponentTest extends TestCase
             ->withParam('action', 'view')
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $controller->loadComponent('Authentication.Authentication');
 
         $controller->Authentication->allowUnauthenticated(['view']);
@@ -434,7 +428,7 @@ class AuthenticationComponentTest extends TestCase
             ->withParam('action', 'view')
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $controller->loadComponent('Authentication.Authentication');
 
         $controller->Authentication->allowUnauthenticated(['view']);
@@ -453,7 +447,7 @@ class AuthenticationComponentTest extends TestCase
             ->withParam('action', 'view')
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $controller->loadComponent('Authentication.Authentication');
 
         $this->expectException(UnauthenticatedException::class);
@@ -473,7 +467,7 @@ class AuthenticationComponentTest extends TestCase
             ->withParam('action', 'view')
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $controller->loadComponent('Authentication.Authentication');
 
         $this->expectException(UnauthenticatedException::class);
@@ -492,7 +486,7 @@ class AuthenticationComponentTest extends TestCase
             ->withParam('action', 'view')
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $controller->loadComponent('Authentication.Authentication', [
             'requireIdentity' => false,
         ]);
@@ -513,7 +507,7 @@ class AuthenticationComponentTest extends TestCase
         $request = $this->request
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -531,7 +525,7 @@ class AuthenticationComponentTest extends TestCase
         $request = $this->request
             ->withAttribute('authentication', $this->service);
 
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -36,7 +36,7 @@ class AuthenticationMiddlewareTest extends TestCase
     /**
      * Fixtures
      */
-    public $fixtures = [
+    protected array $fixtures = [
         'core.AuthUsers',
         'core.Users',
     ];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,6 +46,7 @@ define('CONFIG', ROOT . DS . 'config' . DS);
 Configure::write('debug', true);
 Configure::write('App', [
     'namespace' => 'TestApp',
+    'encoding' => 'UTF-8',
     'paths' => [
         'plugins' => [ROOT . 'Plugin' . DS],
         'templates' => [ROOT . 'templates' . DS],

--- a/tests/test_app/TestApp/Http/TestRequestHandler.php
+++ b/tests/test_app/TestApp/Http/TestRequestHandler.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
  */
 namespace TestApp\Http;
 
+use Cake\Http\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response;
 
 class TestRequestHandler implements RequestHandlerInterface
 {


### PR DESCRIPTION
These are all the changes required to run with the 5.x cakephp branch.

This does not include fixing the code-sniffer issues which are a much larger change that adds native types to everything.