### PR TITLE
Token Identifier: Add Option to Hash Token Before Resolving

### DIFF
--- a/docs/en/authentication-component.rst
+++ b/docs/en/authentication-component.rst
@@ -94,12 +94,12 @@ Configure Automatic Identity Checks
 -----------------------------------
 
 By default ``AuthenticationComponent`` will automatically enforce an identity to
-be present during the ``Controller.initialize`` event. You can have this check
-applied during the ``Controller.startup`` event instead::
+be present during the ``Controller.startup`` event. You can have this check
+applied during the ``Controller.initialize`` event instead::
 
     // In your controller's initialize() method.
     $this->loadComponent('Authentication.Authentication', [
-        'identityCheckEvent' => 'Controller.startup',
+        'identityCheckEvent' => 'Controller.initialize',
     ]);
 
 You can also disable identity checks entirely with the ``requireIdentity``

--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -59,6 +59,9 @@ Configuration options:
    Default is ``token``.
 -  **resolver**: The identity resolver. Default is
    ``Authentication.Orm`` which uses CakePHP ORM.
+-  **hashAlgorithm**: The algorithm used to hash the incoming token
+   with before compairing it to the ``tokenField``. Recommended value is
+   ``sha256```. Default is ``null``.
 
 JWT Subject
 ===========

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -58,7 +58,7 @@ Then update your application's ``middleware()`` method to look like::
             // after routing and body parser.
             ->add(new AuthenticationMiddleware($this));
 
-        return $middlewareQueue();
+        return $middlewareQueue;
     }
 
 .. warning::

--- a/docs/es/authentication-component.rst
+++ b/docs/es/authentication-component.rst
@@ -94,13 +94,13 @@ Configurar comprobaciones de identidad automáticas
 --------------------------------------------------
 
 De forma predeterminada, ``AuthenticationComponent`` automáticamente forzará que una entidad
-esté presente durante el evento ``Controller.initialize``. Puede hacer que esta verificación se
-aplique durante el evento ``Controller.startup`` en su lugar::
+esté presente durante el evento ``Controller.startup``. Puede hacer que esta verificación se
+aplique durante el evento ``Controller.initialize`` en su lugar::
 
     // In your controller's initialize() method.
     $this->loadComponent('Authentication.Authentication', [
-        'identityCheckEvent' => 'Controller.startup',
+        'identityCheckEvent' => 'Controller.initialize',
     ]);
 
-También puede deshabilitar las verificaciones de identidad por completo con la 
+También puede deshabilitar las verificaciones de identidad por completo con la
 opción ``requireIdentity``

--- a/docs/fr/authentication-component.rst
+++ b/docs/fr/authentication-component.rst
@@ -99,12 +99,12 @@ Configurer les Vérifications d'Identité Automatiques
 ----------------------------------------------------
 
 Par défaut, ``AuthenticationComponent`` imposera qu'une identité soit présente
-pendant l'événement ``Controller.initialize``. Vous pouvez faire appliquer cette
-vérification plutôt dans l'événement ``Controller.startup``::
+pendant l'événement ``Controller.startup``. Vous pouvez faire appliquer cette
+vérification plutôt dans l'événement ``Controller.initialize``::
 
     // Dans la méthode initialize() de votre contrôleur.
     $this->loadComponent('Authentication.Authentication', [
-        'identityCheckEvent' => 'Controller.startup',
+        'identityCheckEvent' => 'Controller.initialize',
     ]);
 
 Vous pouvez aussi désactiver entièrement ces vérifications d'identité avec

--- a/docs/ja/authentication-component.rst
+++ b/docs/ja/authentication-component.rst
@@ -91,13 +91,13 @@ identity のログアウト
 自動Identityチェックを構成する
 ---------------------------------
 
-デフォルトでは ``認証コンポーネント`` は、 ``Controller.initialize``
+デフォルトでは ``認証コンポーネント`` は、 ``Controller.startup``
 イベントの間に存在するIDを自動的に強制します。
-このチェックは ``Controller.startup`` イベント中に適用することもできます::
+このチェックは ``Controller.initialize`` イベント中に適用することもできます::
 
     // コントローラの initialize() メソッドの中です。
     $this->loadComponent('Authentication.Authentication', [
-        'identityCheckEvent' => 'Controller.startup',
+        'identityCheckEvent' => 'Controller.initialize',
     ]);
 
 また、 ``requireIdentity`` オプションを使って ID チェックを完全に無効にすることもできます。

--- a/src/Identifier/TokenIdentifier.php
+++ b/src/Identifier/TokenIdentifier.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Authentication\Identifier;
 
 use Authentication\Identifier\Resolver\ResolverAwareTrait;
+use Cake\Utility\Security;
 
 /**
  * Token Identifier
@@ -34,6 +35,7 @@ class TokenIdentifier extends AbstractIdentifier
         'tokenField' => 'token',
         'dataField' => self::CREDENTIAL_TOKEN,
         'resolver' => 'Authentication.Orm',
+        'hashAlgorithm' => null,
     ];
 
     /**
@@ -44,6 +46,13 @@ class TokenIdentifier extends AbstractIdentifier
         $dataField = $this->getConfig('dataField');
         if (!isset($credentials[$dataField])) {
             return null;
+        }
+
+        if ($this->getConfig('hashAlgorithm') !== null) {
+            $credentials[$dataField] = Security::hash(
+                $credentials[$dataField],
+                $this->getConfig('hashAlgorithm')
+            );
         }
 
         $conditions = [

--- a/src/Identity.php
+++ b/src/Identity.php
@@ -94,7 +94,7 @@ class Identity implements IdentityInterface
      * Check if the field isset() using object access.
      *
      * @param string $field Field in the user data.
-     * @return mixed
+     * @return bool
      */
     public function __isset(string $field)
     {

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -69,7 +69,7 @@ class AuthenticationMiddleware implements MiddlewareInterface
      * @param array $config Array of configuration settings.
      * @throws \InvalidArgumentException When invalid subject has been passed.
      */
-    public function __construct($subject, $config = null)
+    public function __construct($subject, $config = [])
     {
         $this->setConfig($config);
 

--- a/tests/TestCase/Identifier/TokenIdentifierTest.php
+++ b/tests/TestCase/Identifier/TokenIdentifierTest.php
@@ -71,4 +71,33 @@ class TokenIdentifierTest extends TestCase
         $result = $identifier->identify(['user' => 'larry']);
         $this->assertNull($result);
     }
+
+    /**
+     * testIdentifyHashed
+     *
+     * @return void
+     */
+    public function testIdentifyHashed()
+    {
+        $resolver = $this->createMock(ResolverInterface::class);
+
+        $identifier = new TokenIdentifier([
+            'hashAlgorithm' => 'sha256',
+        ]);
+        $identifier->setResolver($resolver);
+
+        $user = new ArrayObject([
+            'username' => 'larry',
+        ]);
+
+        $resolver->expects($this->once())
+            ->method('find')
+            ->with([
+                'token' => hash('sha256', 'SomeSecretToken'),
+            ])
+            ->willReturn($user);
+
+        $result = $identifier->identify(['token' => 'SomeSecretToken']);
+        $this->assertSame($user, $result);
+    }
 }

--- a/tests/test_app/TestApp/Http/TestRequestHandler.php
+++ b/tests/test_app/TestApp/Http/TestRequestHandler.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
  */
 namespace TestApp\Http;
 
+use Laminas\Diactoros\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Laminas\Diactoros\Response;
 
 class TestRequestHandler implements RequestHandlerInterface
 {

--- a/tests/test_app/TestApp/Http/TestRequestHandler.php
+++ b/tests/test_app/TestApp/Http/TestRequestHandler.php
@@ -17,7 +17,7 @@ namespace TestApp\Http;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response;
+use Laminas\Diactoros\Response;
 
 class TestRequestHandler implements RequestHandlerInterface
 {


### PR DESCRIPTION
With this change developers can hash values stored in the database and specify a `hashAlgorithm` to apply before forwarding the value to the resolver.

I retained the default behavior of no hash, but we should probably apply some hash by default for security reasons. Then users can disable the hash, but it is secure by default.