### PR TITLE
Add forceLowercase option to PasswordIdentifier

### DIFF
--- a/src/Identifier/PasswordIdentifier.php
+++ b/src/Identifier/PasswordIdentifier.php
@@ -51,6 +51,8 @@ class PasswordIdentifier extends AbstractIdentifier
      * - `fields` The fields to use to identify a user by:
      *   - `username`: one or many username fields.
      *   - `password`: password field.
+     * - `forceLowercase` Forces identifier to lowercase when comparing to
+     *   `username` fields. Allows for case-insensitive comparison.
      * - `resolver` The resolver implementation to use.
      * - `passwordHasher` Password hasher class. Can be a string specifying class name
      *    or an array containing `className` key, any other keys will be passed as
@@ -63,6 +65,7 @@ class PasswordIdentifier extends AbstractIdentifier
             self::CREDENTIAL_USERNAME => 'username',
             self::CREDENTIAL_PASSWORD => 'password',
         ],
+        'forceLowercase' => false,
         'resolver' => 'Authentication.Orm',
         'passwordHasher' => null,
     ];
@@ -148,6 +151,9 @@ class PasswordIdentifier extends AbstractIdentifier
      */
     protected function _findIdentity(string $identifier)
     {
+        if ($this->getConfig('forceLowercase')) {
+            $identifier = strtolower($identifier);
+        }
         $fields = $this->getConfig('fields.' . self::CREDENTIAL_USERNAME);
         $conditions = [];
         foreach ((array)$fields as $field) {

--- a/tests/TestCase/Identifier/PasswordIdentifierTest.php
+++ b/tests/TestCase/Identifier/PasswordIdentifierTest.php
@@ -63,6 +63,37 @@ class PasswordIdentifierTest extends TestCase
         $this->assertSame($user, $result);
     }
 
+    public function testIdentifyLowercase(): void
+    {
+        $resolver = $this->createMock(ResolverInterface::class);
+        $hasher = $this->createMock(PasswordHasherInterface::class);
+
+        $user = new ArrayObject([
+            'username' => 'mariano',
+            'password' => 'h45hedpa55w0rd',
+        ]);
+
+        $resolver->expects($this->once())
+            ->method('find')
+            ->with(['username' => 'mariano'])
+            ->willReturn($user);
+
+        $hasher->expects($this->once())
+            ->method('check')
+            ->with('password', 'h45hedpa55w0rd')
+            ->willReturn(true);
+
+        $identifier = new PasswordIdentifier(['forceLowercase' => true]);
+        $identifier->setResolver($resolver)->setPasswordHasher($hasher);
+
+        $result = $identifier->identify([
+            'username' => 'Mariano',
+            'password' => 'password',
+        ]);
+
+        $this->assertSame($user, $result);
+    }
+
     /**
      * testIdentifyNeedsRehash
      *


### PR DESCRIPTION
This allows case-insensitive usernames when the username is always forced to lowercase when storing in the db.

This can reduce the dependency on the UI to always send case-insensitive strings to the server.