### PR TITLE
EnvironmentAuthenticator

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v6
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open for 120 days with no activity. Remove the `stale` label or comment or this will be closed in 15 days'

--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -94,7 +94,7 @@ Configuration options:
    ``AdapterInterface``.
 -  **options**: Additional LDAP options, like
    ``LDAP_OPT_PROTOCOL_VERSION`` or ``LDAP_OPT_NETWORK_TIMEOUT``. See
-   `php.net <http://php.net/manual/en/function.ldap-set-option.php>`__
+   `php.net <https://php.net/manual/en/function.ldap-set-option.php>`__
    for more valid options.
 
 Callback

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -23,7 +23,7 @@ Load the plugin by adding the following statement in your project's ``src/Applic
 Getting Started
 ===============
 
-The authentication plugin integrates with your application as a `middleware <http://book.cakephp.org/4/en/controllers/middleware.html>`_. It can also
+The authentication plugin integrates with your application as a `middleware <https://book.cakephp.org/4/en/controllers/middleware.html>`_. It can also
 be used as a component to make unauthenticated access simpler. First, let's
 apply the middleware. In **src/Application.php**, add the following to the class
 imports::
@@ -125,7 +125,7 @@ to handle a login form at the ``loginUrl``. Finally we attach an :doc:`identifie
 
 If one of the configured authenticators was able to validate the credentials,
 the middleware will add the authentication service to the request object as an
-`attribute <http://www.php-fig.org/psr/psr-7/>`_.
+`attribute <https://www.php-fig.org/psr/psr-7/>`_.
 
 Next, in your ``AppController`` load the :doc:`/authentication-component`::
 

--- a/docs/en/password-hashers.rst
+++ b/docs/en/password-hashers.rst
@@ -8,7 +8,7 @@ This is using the php constant ``PASSWORD_DEFAULT`` for the encryption
 method. The default hash type is ``bcrypt``.
 
 See `the php
-documentation <http://php.net/manual/en/function.password-hash.php>`__
+documentation <https://php.net/manual/en/function.password-hash.php>`__
 for further information on bcrypt and PHP’s password hashing.
 
 The config options for this adapter are:

--- a/docs/es/identifiers.rst
+++ b/docs/es/identifiers.rst
@@ -94,13 +94,13 @@ Opciones de configuración:
    ``AdapterInterface``.
 -  **options**: Opciones adicionales del LDAP, como
    ``LDAP_OPT_PROTOCOL_VERSION`` o ``LDAP_OPT_NETWORK_TIMEOUT``. Ver
-   `php.net <http://php.net/manual/en/function.ldap-set-option.php>`__
+   `php.net <https://php.net/manual/en/function.ldap-set-option.php>`__
    para mas opciones válidas.
 
 Callback
 ========
 
-Le permite usar un callback para la identificación. Esto es útil para 
+Le permite usar un callback para la identificación. Esto es útil para
 identificadores simples o creación rápida de prototipos.
 
 Opciones de configuración:

--- a/docs/es/index.rst
+++ b/docs/es/index.rst
@@ -21,7 +21,7 @@ Carge el plugin agregando la siguiente declaración en ``src/Application.php``::
 Empezando
 =========
 
-El  plugin authentication se integra con su aplicación como un `middleware <http://book.cakephp.org/4/en/controllers/middleware.html>`_. También, se 
+El  plugin authentication se integra con su aplicación como un `middleware <https://book.cakephp.org/4/en/controllers/middleware.html>`_. También, se
 puede utilizar como un componente para simplificar el acceso no autenticado. Primero
 aplique el middleware. En **src/Application.php**, agregue las siguientes importaciones
 de clase::
@@ -102,12 +102,12 @@ A continuación, adjuntamos la ``Session`` y el ``Form`` :doc:`/authenticators` 
 mecanismos que utilizará nuestra aplicación para autenticar usuarios. ``Session`` nos permite identificar a los
 usuarios en función de los datos de la sesión, mientras que ``Form`` nos permite gestionar un
 formulario de inicio de sesión en el ``loginUrl``. Finalmente adjuntamos un :doc:`identifier
-</identifiers>` para convertir las credenciales que los usuarios nos darán en un 
+</identifiers>` para convertir las credenciales que los usuarios nos darán en un
 :doc:`identity </identity-object>` que representa nuestro usuario registrado.
 
 Si uno de los autenticadores configurados pudo validar las credenciales,
 el middleware agregará el servicio de autenticación al objeto request como un
-`attribute <http://www.php-fig.org/psr/psr-7/>`_.
+`attribute <https://www.php-fig.org/psr/psr-7/>`_.
 
 A continuación, en su ``AppController`` cargue el :doc:`/authentication-component`::
 
@@ -130,7 +130,7 @@ Puede deshabilitar este comportamiento en controladores específicos usando
 Creación de una acción Login
 ============================
 
-Una vez que haya aplicado el middleware a su aplicación, necesitará una forma para que los 
+Una vez que haya aplicado el middleware a su aplicación, necesitará una forma para que los
 usuarios inicien sesión. Primero genere un modelo y un controlador de usuarios con ``bake``:
 
 .. code-block:: shell
@@ -138,7 +138,7 @@ usuarios inicien sesión. Primero genere un modelo y un controlador de usuarios 
     bin/cake bake model Users
     bin/cake bake controller Users
 
-Luego, agregue una acción login a su ``UsersController``. Debería verse 
+Luego, agregue una acción login a su ``UsersController``. Debería verse
 así::
 
     // in src/Controller/UsersController.php
@@ -155,7 +155,7 @@ así::
         }
     }
 
-Asegúrese de permitir el acceso a la acción ``login`` en su contralador en 
+Asegúrese de permitir el acceso a la acción ``login`` en su contralador en
 ``beforeFilter()`` callback como se menciona en la sección anterior, así
 los usuarios no autenticados puedan acceder a ella::
 

--- a/docs/es/password-hashers.rst
+++ b/docs/es/password-hashers.rst
@@ -8,7 +8,7 @@ Usando la constante php ``PASSWORD_DEFAULT`` para el método de encriptación.
 El tipo de hash por defecto es ``bcrypt``.
 
 Ver `la documentación
-php <http://php.net/manual/en/function.password-hash.php>`__
+php <https://php.net/manual/en/function.password-hash.php>`__
 para obtener más información sobre bcrypt y el hash de contraseñas de PHP.
 
 Las opciones de configuración de este adaptador son:
@@ -38,7 +38,7 @@ Actualización de algoritmos hash
 CakePHP proporciona una forma limpia de migrar las contraseñas de sus
 usuarios de un algoritmo a otro, esto se logra a través de la clase
 ``FallbackPasswordHasher``. Suponiendo que desea migrar de una contraseña
-Legacy a el hasher bcrypt predeterminado, puede configurar el hasher fallback 
+Legacy a el hasher bcrypt predeterminado, puede configurar el hasher fallback
 de la siguiente manera::
 
    $service->loadIdentifier('Authentication.Password', [

--- a/docs/fr/identifiers.rst
+++ b/docs/fr/identifiers.rst
@@ -97,7 +97,7 @@ Options de configuration:
    l'\ ``AdapterInterface``.
 -  **options**: Options supplémentaires LDAP, telles que
    ``LDAP_OPT_PROTOCOL_VERSION`` ou ``LDAP_OPT_NETWORK_TIMEOUT``. Cf.
-   `php.net <http://php.net/manual/en/function.ldap-set-option.php>`__
+   `php.net <https://php.net/manual/en/function.ldap-set-option.php>`__
    pour en savoir plus sur les options valides.
 
 Callback

--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -26,7 +26,7 @@ Pour commencer
 ==============
 
 Le plugin d'authentification s'intègre dans votre application comme un
-`middleware <http://book.cakephp.org/4/en/controllers/middleware.html>`_. Il
+`middleware <https://book.cakephp.org/4/en/controllers/middleware.html>`_. Il
 peut aussi être utilisé comme un composant pour faciliter l'accès sans
 authentification. Tout d'abord, mettons en place le middleware. Dans votre
 **src/Application.php**, ajoutez ce qui suit aux imports de la classe::
@@ -63,7 +63,7 @@ Puis modifier votre méthode ``middleware()`` pour la faire ressembler à ceci::
 
         return $middlewareQueue();
     }
- 
+
 .. warning::
     L'ordre des middlewares est important. Assurez-vous d'avoir
     ``AuthenticationMiddleware`` après les middlewares routing et body parser.
@@ -132,7 +132,7 @@ identifiants que l'utilisateur nous donnera en une
 
 Si l'un des authentificateurs configurés a été en mesure de valider les
 identifiants utilisateur, le middleware ajoutera le service d'authentification à
-l'objet requête en tant qu'\ `attribut <http://www.php-fig.org/psr/psr-7/>`_.
+l'objet requête en tant qu'\ `attribut <https://www.php-fig.org/psr/psr-7/>`_.
 
 Ensuite, chargez le :doc:`/authentication-component` dans votre
 ``AppController``::

--- a/docs/ja/identifiers.rst
+++ b/docs/ja/identifiers.rst
@@ -73,7 +73,7 @@ LDAP サーバーに対して渡された資格情報をチェックします。
 -  **ldap**: 延長アダプターです。 デフォルトは ``\Authentication\Identifier\Ldap\ExtensionAdapter``。
    もしそれが ``AdapterInterface`` を実装しているならば、そのobject/classnameをここに渡すことができます。
 -  **options**: 付加的な LDAP オプション, like ``LDAP_OPT_PROTOCOL_VERSION`` または ``LDAP_OPT_NETWORK_TIMEOUT`` のようなものです。
-   `php.net <http://php.net/manual/en/function.ldap-set-option.php>`__ をみてより多くのオプションを参照してください。
+   `php.net <https://php.net/manual/en/function.ldap-set-option.php>`__ をみてより多くのオプションを参照してください。
 
 コールバック
 ============

--- a/docs/ja/index.rst
+++ b/docs/ja/index.rst
@@ -22,7 +22,7 @@ CakePHPから `composer <https://getcomposer.org/>`_ でプラグインをイン
 はじめに
 ===============
 
-認証プラグインは、ミドルウェアとしてアプリケーションと統合します。 `middleware <http://book.cakephp.org/4/en/controllers/middleware.html>`_
+認証プラグインは、ミドルウェアとしてアプリケーションと統合します。 `middleware <https://book.cakephp.org/4/en/controllers/middleware.html>`_
 また、認証されていないアクセスをより簡単にするためのコンポーネントとして使用することもできます。  まずはミドルウェアを適用してみましょう。
 
 **src/Application.php** に以下のクラスを追加します。
@@ -93,7 +93,7 @@ CakePHPから `composer <https://getcomposer.org/>`_ でプラグインをイン
 
 最後に、ログインしたユーザーを表す :doc:`identifier </identifiers>` に変換するための :doc:`identity </identity-object>` をアタッチします。
 
-認証が確認できた場合、ミドルウェアは認証サービスを `属性 <http://www.php-fig.org/psr/psr-7/>`_. としてリクエストオブジェクトに追加します。
+認証が確認できた場合、ミドルウェアは認証サービスを `属性 <https://www.php-fig.org/psr/psr-7/>`_. としてリクエストオブジェクトに追加します。
 
 次に、 ``AppController`` に :doc:`/authentication-component` を呼び出します。::
 

--- a/docs/ja/password-hashers.rst
+++ b/docs/ja/password-hashers.rst
@@ -8,7 +8,7 @@ Default
 デフォルトのハッシュ型は ``bcrypt`` です。
 
 
-こちらをご覧ください `PHPのドキュメント <http://php.net/manual/en/function.password-hash.php>`__
+こちらをご覧ください `PHPのドキュメント <https://php.net/manual/en/function.password-hash.php>`__
 bcryptとPHPのパスワードハッシュについての詳細情報が書かれています。
 
 このアダプタの設定オプションは次のとおりです:

--- a/readme.md
+++ b/readme.md
@@ -43,4 +43,4 @@ Documentation for this plugin can be found in the [CakePHP Cookbook](https://boo
 
 ## IDE compatibility improvements
 
-For `FormatHelper::icon()` you an find a IdeHelper task in [IdeHelperExtra plugin](https://github.com/dereuromark/cakephp-ide-helper-extra/).
+For `AuthenticationService::loadIdentifier()` you an find an IdeHelper task in [IdeHelperExtra plugin](https://github.com/dereuromark/cakephp-ide-helper-extra/).

--- a/readme.md
+++ b/readme.md
@@ -40,3 +40,7 @@ public function bootstrap(): void
 ## Documentation
 
 Documentation for this plugin can be found in the [CakePHP Cookbook](https://book.cakephp.org/authentication/2/en/).
+
+## IDE compatibility improvements
+
+For `FormatHelper::icon()` you an find a IdeHelper task in [IdeHelperExtra plugin](https://github.com/dereuromark/cakephp-ide-helper-extra/).

--- a/src/Authenticator/AuthenticationRequiredException.php
+++ b/src/Authenticator/AuthenticationRequiredException.php
@@ -27,7 +27,7 @@ use Cake\Http\Exception\HttpException;
 class AuthenticationRequiredException extends HttpException
 {
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $headers = [];
 
@@ -53,7 +53,7 @@ class AuthenticationRequiredException extends HttpException
     /**
      * Get the headers.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getHeaders(): array
     {

--- a/src/Authenticator/EnvironmentAuthenticator.php
+++ b/src/Authenticator/EnvironmentAuthenticator.php
@@ -33,7 +33,7 @@ class EnvironmentAuthenticator extends AbstractAuthenticator
      * - `loginUrl` Login URL or an array of URLs.
      * - `urlChecker` Url checker config.
      * - `fields` array of required fields to get from the environment
-     * - `optional_fields` array of optional fields to get from the environment
+     * - `optionalFields` array of optional fields to get from the environment
      *
      * @var array
      */
@@ -41,7 +41,7 @@ class EnvironmentAuthenticator extends AbstractAuthenticator
         'loginUrl' => null,
         'urlChecker' => 'Authentication.Default',
         'fields' => [],
-        'optional_fields' => [],
+        'optionalFields' => [],
     ];
 
     /**
@@ -73,14 +73,14 @@ class EnvironmentAuthenticator extends AbstractAuthenticator
     }
 
     /**
-     * Get values from the environment variables configured by `optional_fields`.
+     * Get values from the environment variables configured by `optionalFields`.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
-     * @return array server params defined by optional_fields.
+     * @return array server params defined by optionalFields.
      */
     protected function _getOptionalData(ServerRequestInterface $request): array
     {
-        $fields = $this->_config['optional_fields'];
+        $fields = $this->_config['optionalFields'];
         $params = $request->getServerParams();
 
         $data = [];

--- a/src/Authenticator/EnvironmentAuthenticator.php
+++ b/src/Authenticator/EnvironmentAuthenticator.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         2.10.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authentication\Authenticator;
+
+use Authentication\UrlChecker\UrlCheckerTrait;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Environment Authenticator
+ *
+ * Authenticates an identity based on the POST data of the request.
+ */
+class EnvironmentAuthenticator extends AbstractAuthenticator
+{
+    use UrlCheckerTrait;
+
+    /**
+     * Default config for this object.
+     * - `loginUrl` Login URL or an array of URLs.
+     * - `urlChecker` Url checker config.
+     * - `fields` array of required fields to get from the environment
+     * - `optional_fields` array of optional fields to get from the environment
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'loginUrl' => null,
+        'urlChecker' => 'Authentication.Default',
+        'fields' => [],
+        'optional_fields' => [],
+    ];
+
+    /**
+     * Get values from the environment variables configured by `fields`.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
+     * @return array|null server params defined by `fields` or null if a field is missing.
+     */
+    protected function _getData(ServerRequestInterface $request): ?array
+    {
+        $fields = $this->_config['fields'];
+        $params = $request->getServerParams();
+
+        $data = [];
+        foreach ($fields as $field) {
+            if (!isset($params[$field])) {
+                return null;
+            }
+
+            $value = $params[$field];
+            if (!is_string($value) || !strlen($value)) {
+                return null;
+            }
+
+            $data[$field] = $value;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get values from the environment variables configured by `optional_fields`.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
+     * @return array server params defined by optional_fields.
+     */
+    protected function _getOptionalData(ServerRequestInterface $request): array
+    {
+        $fields = $this->_config['optional_fields'];
+        $params = $request->getServerParams();
+
+        $data = [];
+        foreach ($fields as $field) {
+            if (isset($params[$field])) {
+                $data[$field] = $params[$field];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Prepares the error object for a login URL error
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
+     * @return \Authentication\Authenticator\ResultInterface
+     */
+    protected function _buildLoginUrlErrorResult(ServerRequestInterface $request): ResultInterface
+    {
+        $uri = $request->getUri();
+        $base = $request->getAttribute('base');
+        if ($base !== null) {
+            $uri = $uri->withPath((string)$base . $uri->getPath());
+        }
+
+        $checkFullUrl = $this->getConfig('urlChecker.checkFullUrl', false);
+        if ($checkFullUrl) {
+            $uri = (string)$uri;
+        } else {
+            $uri = $uri->getPath();
+        }
+
+        $errors = [
+            sprintf(
+                'Login URL `%s` did not match `%s`.',
+                $uri,
+                implode('` or `', (array)$this->getConfig('loginUrl'))
+            ),
+        ];
+
+        return new Result(null, Result::FAILURE_OTHER, $errors);
+    }
+
+    /**
+     * Authenticates the identity contained in a request.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
+     * @return \Authentication\Authenticator\ResultInterface
+     */
+    public function authenticate(ServerRequestInterface $request): ResultInterface
+    {
+        if (!$this->_checkUrl($request)) {
+            return $this->_buildLoginUrlErrorResult($request);
+        }
+        $data = $this->_getData($request);
+        if (empty($data)) {
+            return new Result(null, Result::FAILURE_CREDENTIALS_MISSING, [
+                'Environment credentials not found',
+            ]);
+        }
+
+        $data = array_merge($this->_getOptionalData($request), $data);
+
+        $user = $this->_identifier->identify($data);
+
+        if (empty($user)) {
+            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
+        }
+
+        return new Result($user, Result::SUCCESS);
+    }
+}

--- a/src/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Authenticator/HttpBasicAuthenticator.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;
 

--- a/src/Authenticator/HttpDigestAuthenticator.php
+++ b/src/Authenticator/HttpDigestAuthenticator.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;
 

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;
 

--- a/src/Identity.php
+++ b/src/Identity.php
@@ -124,7 +124,7 @@ class Identity implements IdentityInterface
     /**
      * Whether a offset exists
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @link https://php.net/manual/en/arrayaccess.offsetexists.php
      * @param mixed $offset Offset
      * @return bool
      */
@@ -136,7 +136,7 @@ class Identity implements IdentityInterface
     /**
      * Offset to retrieve
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     * @link https://php.net/manual/en/arrayaccess.offsetget.php
      * @param mixed $offset Offset
      * @return mixed
      */
@@ -149,7 +149,7 @@ class Identity implements IdentityInterface
     /**
      * Offset to set
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     * @link https://php.net/manual/en/arrayaccess.offsetset.php
      * @param mixed $offset The offset to assign the value to.
      * @param mixed $value Value
      * @throws \BadMethodCallException
@@ -164,7 +164,7 @@ class Identity implements IdentityInterface
     /**
      * Offset to unset
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @link https://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset Offset
      * @throws \BadMethodCallException
      * @return void

--- a/src/PasswordHasher/AbstractPasswordHasher.php
+++ b/src/PasswordHasher/AbstractPasswordHasher.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;
 

--- a/src/PasswordHasher/DefaultPasswordHasher.php
+++ b/src/PasswordHasher/DefaultPasswordHasher.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;
 

--- a/src/PasswordHasher/FallbackPasswordHasher.php
+++ b/src/PasswordHasher/FallbackPasswordHasher.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;
 

--- a/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/src/PasswordHasher/LegacyPasswordHasher.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;
 

--- a/src/PasswordHasher/PasswordHasherFactory.php
+++ b/src/PasswordHasher/PasswordHasherFactory.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;
 

--- a/src/PasswordHasher/PasswordHasherInterface.php
+++ b/src/PasswordHasher/PasswordHasherInterface.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\PasswordHasher;
 

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link http://cakephp.org CakePHP(tm) Project
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
  * @since 4.0.0
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Test\TestCase\Authenticator;
 

--- a/tests/TestCase/Authenticator/EnvironmentAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/EnvironmentAuthenticatorTest.php
@@ -1,0 +1,552 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
+ * @since 2.10.0
+ * @license https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authentication\Test\TestCase\Authenticator;
+
+use Authentication\Authenticator\EnvironmentAuthenticator;
+use Authentication\Authenticator\Result;
+use Authentication\Identifier\IdentifierCollection;
+use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
+use Cake\Http\ServerRequestFactory;
+use Cake\Http\Uri;
+use RuntimeException;
+
+class EnvironmentAuthenticatorTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'core.AuthUsers',
+        'core.Users',
+    ];
+
+    /**
+     * Identifiers
+     *
+     * @var \Authentication\Identifier\IdentifierCollection
+     */
+    public $identifiers;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->identifiers = new IdentifierCollection([
+           'Authentication.Token' => [
+               'tokenField' => 'username',
+               'dataField' => 'USER_ID',
+           ],
+        ]);
+    }
+
+    /**
+     * testAuthenticate
+     *
+     * @return void
+     */
+    public function testAuthenticate()
+    {
+        $identifiers = new IdentifierCollection([
+            'Authentication.Callback' => [
+                'callback' => function ($data) {
+                    if (isset($data['USER_ID']) && isset($data['ATTRIBUTE'])) {
+                        return new Result($data, RESULT::SUCCESS);
+                    }
+
+                       return null;
+                },
+            ],
+        ]);
+        $envAuth = new EnvironmentAuthenticator($identifiers, [
+            'loginUrl' => '/secure',
+            'fields' => [
+                'USER_ID',
+                'ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/secure',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus(), '2 required fields used for authentication');
+    }
+
+    /**
+     * testFailedAuthentication
+     *
+     * @return void
+     */
+    public function testFailedAuthentication()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '/secure',
+            'fields' => [
+                'USER_ID',
+                'SOME_ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/secure',
+            'USER_ID' => 'Guy',
+            'SOME_ATTRIBUTE' => 'dondecourse',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+    }
+
+    /**
+     * testWithoutFieldConfig
+     *
+     * @return void
+     */
+    public function testWithoutFieldConfig()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers);
+
+        $result = $envAuth->authenticate(ServerRequestFactory::fromGlobals());
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+    }
+
+    /**
+     * testWithIncorrectFieldConfig
+     *
+     * @return void
+     */
+    public function testWithIncorrectFieldConfig()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '/secure',
+            'fields' => [
+                'INCORRECT_USER_ID',
+                'SOME_ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/secure',
+            'USER_ID' => 'mariano',
+            'SOME_ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+    }
+
+    /**
+     * testCredentialsEmpty
+     *
+     * @return void
+     */
+    public function testCredentialsEmpty()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '/secure',
+            'fields' => [
+                'USER_ID',
+                'SOME_ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/secure',
+            'USER_ID' => '',
+            'SOME_ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_CREDENTIALS_MISSING, $result->getStatus());
+    }
+
+    /**
+     * testOptionalFields
+     *
+     * @return void
+     */
+    public function testOptionalFields()
+    {
+        $identifiers = new IdentifierCollection([
+           'Authentication.Callback' => [
+               'callback' => function ($data) {
+                if (isset($data['USER_ID']) && isset($data['OPTIONAL_FIELD'])) {
+                    return new Result($data, RESULT::SUCCESS);
+                }
+
+                       return null;
+               },
+           ],
+        ]);
+        $envAuth = new EnvironmentAuthenticator($identifiers, [
+            'loginUrl' => '/secure',
+            'fields' => [
+                'USER_ID',
+                'SOME_ATTRIBUTE',
+            ],
+            'optional_fields' => [
+                'OPTIONAL_FIELD',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/secure',
+            'USER_ID' => 'mariano',
+            'SOME_ATTRIBUTE' => 'anything',
+            'OPTIONAL_FIELD' => 'gotcha',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus(), 'Optional field used for authentication');
+    }
+
+    /**
+     * testSingleLoginUrlMismatch
+     *
+     * @return void
+     */
+    public function testSingleLoginUrlMismatch()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '/secure',
+            'fields' => [
+                'USER_ID',
+                'ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/de/secure',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertEquals([0 => 'Login URL `/de/secure` did not match `/secure`.'], $result->getErrors());
+    }
+
+    /**
+     * testMultipleLoginUrlMismatch
+     *
+     * @return void
+     */
+    public function testMultipleLoginUrlMismatch()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => [
+                '/en/secure',
+                '/de/secure',
+            ],
+            'fields' => [
+                'USER_ID',
+                'ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/fr/secure',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertEquals([0 => 'Login URL `/fr/secure` did not match `/en/secure` or `/de/secure`.'], $result->getErrors());
+    }
+
+    /**
+     * testSingleLoginUrlSuccess
+     *
+     * @return void
+     */
+    public function testSingleLoginUrlSuccess()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '/en/secure',
+            'fields' => [
+                'USER_ID',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/en/secure',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
+        $this->assertEquals([], $result->getErrors());
+    }
+
+    /**
+     * testMultipleLoginUrlSuccess
+     *
+     * @return void
+     */
+    public function testMultipleLoginUrlSuccess()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => [
+                '/en/secure',
+                '/de/secure',
+            ],
+            'fields' => [
+                'USER_ID',
+                'ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/de/secure',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
+        $this->assertEquals([], $result->getErrors());
+    }
+
+    /**
+     * testLoginUrlSuccessWithBase
+     *
+     * @return void
+     */
+    public function testLoginUrlSuccessWithBase()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '/base/fr/secure',
+            'fields' => [
+                'USER_ID',
+                'ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/fr/secure',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+        $uri = new Uri($request->getUri(), '/base', '/');
+        $request = $request->withUri($uri);
+        $request = $request->withAttribute('base', $uri->getBase());
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
+        $this->assertEquals([], $result->getErrors());
+    }
+
+    /**
+     * testRegexLoginUrlSuccess
+     *
+     * @return void
+     */
+    public function testRegexLoginUrlSuccess()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '%^/[a-z]{2}/users/secure/?$%',
+            'urlChecker' => [
+                'useRegex' => true,
+            ],
+            'fields' => [
+                'USER_ID',
+                'ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/fr/users/secure',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
+        $this->assertEquals([], $result->getErrors());
+    }
+
+    /**
+     * testFullRegexLoginUrlFailure
+     *
+     * @return void
+     */
+    public function testFullRegexLoginUrlFailure()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '%auth\.localhost/[a-z]{2}/users/secure/?$%',
+            'urlChecker' => [
+                'useRegex' => true,
+                'checkFullUrl' => true,
+            ],
+            'fields' => [
+                'USER_ID',
+                'ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/fr/users/secure',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertEquals([0 => 'Login URL `http://localhost/fr/users/secure` did not match `%auth\.localhost/[a-z]{2}/users/secure/?$%`.'], $result->getErrors());
+    }
+
+    /**
+     * testRegexLoginUrlSuccess
+     *
+     * @return void
+     */
+    public function testFullRegexLoginUrlSuccess()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '%auth\.localhost/[a-z]{2}/users/secure/?$%',
+            'urlChecker' => [
+                'useRegex' => true,
+                'checkFullUrl' => true,
+            ],
+            'fields' => [
+                'USER_ID',
+                'ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/fr/users/secure',
+            'SERVER_NAME' => 'auth.localhost',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
+        $this->assertEquals([], $result->getErrors());
+    }
+
+    /**
+     * testFullLoginUrlFailureWithoutCheckFullUrlOption
+     *
+     * @return void
+     */
+    public function testFullLoginUrlFailureWithoutCheckFullUrlOption()
+    {
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => 'http://localhost/secure',
+            'fields' => [
+                'USER_ID',
+                'ATTRIBUTE',
+            ],
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/secure',
+            'USER_ID' => 'mariano',
+            'ATTRIBUTE' => 'anything',
+        ]);
+
+        $result = $envAuth->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_OTHER, $result->getStatus());
+        $this->assertEquals([0 => 'Login URL `/secure` did not match `http://localhost/secure`.'], $result->getErrors());
+    }
+
+    /**
+     * testAuthenticateValidData
+     *
+     * @return void
+     */
+    public function testAuthenticateMissingChecker()
+    {
+        $this->createMock(IdentifierCollection::class);
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '/secure',
+            'fields' => [
+                'USER_ID',
+                'SOME_ATTRIBUTE',
+            ],
+            'urlChecker' => 'Foo',
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/secure',
+            'USER_ID' => 'mariano',
+            'SOME_ATTRIBUTE' => 'anything',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('URL checker class `Foo` was not found.');
+
+        $envAuth->authenticate($request);
+    }
+
+    /**
+     * testAuthenticateInvalidChecker
+     *
+     * @return void
+     */
+    public function testAuthenticateInvalidChecker()
+    {
+        $this->createMock(IdentifierCollection::class);
+        $envAuth = new EnvironmentAuthenticator($this->identifiers, [
+            'loginUrl' => '/secure',
+            'fields' => [
+                'USER_ID',
+                'SOME_ATTRIBUTE',
+            ],
+            'urlChecker' => self::class,
+        ]);
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/secure',
+            'USER_ID' => 'mariano',
+            'SOME_ATTRIBUTE' => 'anything',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'The provided URL checker class `Authentication\Test\TestCase\Authenticator\EnvironmentAuthenticatorTest` ' .
+            'does not implement the `Authentication\UrlChecker\UrlCheckerInterface` interface.'
+        );
+
+        $envAuth->authenticate($request);
+    }
+}

--- a/tests/TestCase/Authenticator/EnvironmentAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/EnvironmentAuthenticatorTest.php
@@ -211,7 +211,7 @@ class EnvironmentAuthenticatorTest extends TestCase
                 'USER_ID',
                 'SOME_ATTRIBUTE',
             ],
-            'optional_fields' => [
+            'optionalFields' => [
                 'OPTIONAL_FIELD',
             ],
         ]);

--- a/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/HttpDigestAuthenticatorTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 /**
  * HttpDigestAuthenticatorTest file
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link http://cakephp.org CakePHP(tm) Project
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Test\TestCase\Authenticator;
 

--- a/tests/TestCase/PasswordHasher/DefaultPasswordHasherTest.php
+++ b/tests/TestCase/PasswordHasher/DefaultPasswordHasherTest.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link http://cakephp.org CakePHP(tm) Project
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Test\TestCase\PasswordHasher;
 

--- a/tests/TestCase/PasswordHasher/FallbackPasswordHasherTest.php
+++ b/tests/TestCase/PasswordHasher/FallbackPasswordHasherTest.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link http://cakephp.org CakePHP(tm) Project
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Test\TestCase\PasswordHasher;
 

--- a/tests/TestCase/PasswordHasher/LegacyPasswordHasherTest.php
+++ b/tests/TestCase/PasswordHasher/LegacyPasswordHasherTest.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link http://cakephp.org CakePHP(tm) Project
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Test\TestCase\PasswordHasher;
 

--- a/tests/TestCase/PasswordHasher/PasswordHasherFactoryTest.php
+++ b/tests/TestCase/PasswordHasher/PasswordHasherFactoryTest.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link http://cakephp.org CakePHP(tm) Project
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Test\TestCase\PasswordHasher;
 

--- a/tests/TestCase/PasswordHasher/PasswordHasherTraitTest.php
+++ b/tests/TestCase/PasswordHasher/PasswordHasherTraitTest.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link http://cakephp.org CakePHP(tm) Project
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Test\TestCase\PasswordHasher;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 
 use Cake\Core\Configure;

--- a/tests/test_app/Plugin/TestPlugin/src/PasswordHasher/LegacyPasswordHasher.php
+++ b/tests/test_app/Plugin/TestPlugin/src/PasswordHasher/LegacyPasswordHasher.php
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link http://cakephp.org CakePHP(tm) Project
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestPlugin\PasswordHasher;
 

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -2,14 +2,14 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp;
 

--- a/tests/test_app/TestApp/Authentication/Identifier/InvalidIdentifier.php
+++ b/tests/test_app/TestApp/Authentication/Identifier/InvalidIdentifier.php
@@ -2,14 +2,14 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Authentication\Identifier;
 

--- a/tests/test_app/TestApp/Callback/MyCallback.php
+++ b/tests/test_app/TestApp/Callback/MyCallback.php
@@ -2,14 +2,14 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Callback;
 

--- a/tests/test_app/TestApp/Http/TestRequestHandler.php
+++ b/tests/test_app/TestApp/Http/TestRequestHandler.php
@@ -2,15 +2,15 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link http://cakephp.org CakePHP(tm) Project
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link https://cakephp.org CakePHP(tm) Project
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Http;
 

--- a/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
@@ -2,14 +2,14 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Model\Table;
 

--- a/tests/test_app/TestApp/PasswordHasher/InvalidPasswordHasher.php
+++ b/tests/test_app/TestApp/PasswordHasher/InvalidPasswordHasher.php
@@ -2,14 +2,14 @@
 declare(strict_types=1);
 
 /**
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice
  *
- * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @license https://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\PasswordHasher;
 


### PR DESCRIPTION
Hi,
My institute uses [Shibboleth](https://shibboleth.atlassian.net/wiki/spaces/CONCEPT/overview) as SSO. After identification by the identity provider, the credentials are injected as environment variables by the http server. This authenticator is a TokenAuthenticator but:

- for server variables,  
- not limited to one token, 
- and checks url.

I don't know if there are other SSO technologies outside Shibboleth that uses environment variable to pass credentials, and have no idea how spread Shibboleth is.

Usage

```
  1         $service->loadAuthenticator('Authentication.Environment', [
  2             'loginUrl' => $service->getConfig('unauthenticatedRedirect'),
  3             'attributes' => [
  4                 'ENV_VAR_1' => 'app_var_1',
  5                 'ENV_VAR_2' => 'app_var_2',
  6             ],
  7         ]);
```
