### PR TITLE
3.x: fix Uri class usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
     },
+    "minimum-stability": "dev",
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/src/UrlChecker/CakeRouterUrlChecker.php
+++ b/src/UrlChecker/CakeRouterUrlChecker.php
@@ -42,7 +42,7 @@ class CakeRouterUrlChecker extends DefaultUrlChecker
     public function check(ServerRequestInterface $request, $loginUrls, array $options = []): bool
     {
         $options = $this->_mergeDefaultOptions($options);
-        $url = $this->_getUrlFromRequest($request->getUri(), $options['checkFullUrl']);
+        $url = $this->_getUrlFromRequest($request, $options['checkFullUrl']);
 
         if (!is_array($loginUrls) || empty($loginUrls)) {
             throw new InvalidArgumentException('The $loginUrls parameter is empty or not of type array.');

--- a/src/UrlChecker/DefaultUrlChecker.php
+++ b/src/UrlChecker/DefaultUrlChecker.php
@@ -18,7 +18,6 @@ namespace Authentication\UrlChecker;
 
 use Cake\Core\Configure;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\UriInterface;
 
 /**
  * Checks if a request object contains a valid URL
@@ -53,7 +52,7 @@ class DefaultUrlChecker implements UrlCheckerInterface
 
         $checker = $this->_getChecker($options);
 
-        $url = $this->_getUrlFromRequest($request->getUri(), $options['checkFullUrl']);
+        $url = $this->_getUrlFromRequest($request, $options['checkFullUrl']);
 
         foreach ($urls as $validUrl) {
             if ($checker($validUrl, $url)) {
@@ -99,14 +98,19 @@ class DefaultUrlChecker implements UrlCheckerInterface
     /**
      * Returns current url.
      *
-     * @param \Psr\Http\Message\UriInterface $uri Server Request
+     * @param \Psr\Http\Message\ServerRequestInterface $request Server Request
      * @param bool $getFullUrl Get the full URL or just the path
      * @return string
      */
-    protected function _getUrlFromRequest(UriInterface $uri, bool $getFullUrl = false): string
+    protected function _getUrlFromRequest(ServerRequestInterface $request, bool $getFullUrl = false): string
     {
+        $uri = $request->getUri();
+
+        $requestBase = $request->getAttribute('base');
         $appBase = Configure::read('App.base');
-        if ($appBase) {
+        if ($requestBase) {
+            $uri = $uri->withPath($requestBase . $uri->getPath());
+        } elseif ($appBase) {
             $uri = $uri->withPath($appBase . $uri->getPath());
         }
 

--- a/src/UrlChecker/DefaultUrlChecker.php
+++ b/src/UrlChecker/DefaultUrlChecker.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Authentication\UrlChecker;
 
+use Cake\Core\Configure;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -104,9 +105,9 @@ class DefaultUrlChecker implements UrlCheckerInterface
      */
     protected function _getUrlFromRequest(UriInterface $uri, bool $getFullUrl = false): string
     {
-        if (property_exists($uri, 'base')) {
-            /** @psalm-suppress NoInterfaceProperties  */
-            $uri = $uri->withPath($uri->base . $uri->getPath());
+        $appBase = Configure::read('App.base');
+        if ($appBase) {
+            $uri = $uri->withPath($appBase . $uri->getPath());
         }
 
         if ($getFullUrl) {

--- a/src/UrlChecker/DefaultUrlChecker.php
+++ b/src/UrlChecker/DefaultUrlChecker.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Authentication\UrlChecker;
 
-use Cake\Core\Configure;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -107,11 +106,8 @@ class DefaultUrlChecker implements UrlCheckerInterface
         $uri = $request->getUri();
 
         $requestBase = $request->getAttribute('base');
-        $appBase = Configure::read('App.base');
         if ($requestBase) {
             $uri = $uri->withPath($requestBase . $uri->getPath());
-        } elseif ($appBase) {
-            $uri = $uri->withPath($appBase . $uri->getPath());
         }
 
         if ($getFullUrl) {

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -28,10 +28,10 @@ use Authentication\Identity;
 use Authentication\IdentityInterface;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\Exception\UnauthorizedException;
+use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
-use Cake\Http\Uri;
 use Cake\I18n\DateTime;
 use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
@@ -821,11 +821,10 @@ class AuthenticationServiceTest extends TestCase
 
     public function testGetUnauthenticatedRedirectUrlWithBasePath()
     {
+        Configure::write('App.base', '/base');
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/secrets']
         );
-        $uri = $request->getUri();
-        $request = $request->withUri(new Uri($uri, '/base', $uri->webroot));
 
         $service = new AuthenticationService([
             'unauthenticatedRedirect' => '/users/login',

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -28,7 +28,6 @@ use Authentication\Identity;
 use Authentication\IdentityInterface;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\Exception\UnauthorizedException;
-use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -821,10 +821,10 @@ class AuthenticationServiceTest extends TestCase
 
     public function testGetUnauthenticatedRedirectUrlWithBasePath()
     {
-        Configure::write('App.base', '/base');
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/secrets']
         );
+        $request = $request->withAttribute('base', '/base');
 
         $service = new AuthenticationService([
             'unauthenticatedRedirect' => '/users/login',

--- a/tests/TestCase/Authenticator/EnvironmentAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/EnvironmentAuthenticatorTest.php
@@ -21,7 +21,6 @@ use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Cake\Http\ServerRequestFactory;
-use Cake\Http\Uri;
 use RuntimeException;
 
 class EnvironmentAuthenticatorTest extends TestCase
@@ -360,9 +359,7 @@ class EnvironmentAuthenticatorTest extends TestCase
             'USER_ID' => 'mariano',
             'ATTRIBUTE' => 'anything',
         ]);
-        $uri = new Uri($request->getUri(), '/base', '/');
-        $request = $request->withUri($uri);
-        $request = $request->withAttribute('base', $uri->getBase());
+        $request = $request->withAttribute('base', '/base');
 
         $result = $envAuth->authenticate($request);
 

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -20,8 +20,8 @@ use Authentication\Authenticator\FormAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
+use Cake\Core\Configure;
 use Cake\Http\ServerRequestFactory;
-use Cake\Http\Uri;
 use RuntimeException;
 
 class FormAuthenticatorTest extends TestCase
@@ -182,15 +182,13 @@ class FormAuthenticatorTest extends TestCase
             'Authentication.Password',
         ]);
 
+        Configure::write('App.base', '/base');
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/users/login'],
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $uri = $request->getUri();
-        $uri = new Uri($uri, '/base', $uri->webroot);
-        $request = $request->withUri($uri);
-        $request = $request->withAttribute('base', $uri->base);
+        $request = $request->withAttribute('base', '/base');
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/users/login',
@@ -273,14 +271,13 @@ class FormAuthenticatorTest extends TestCase
             'Authentication.Password',
         ]);
 
+        Configure::write('App.base', '/base');
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/users/login'],
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $uri = new Uri($request->getUri(), '/base', '/');
-        $request = $request->withUri($uri);
-        $request = $request->withAttribute('base', $uri->base);
+        $request = $request->withAttribute('base', '/base');
 
         $form = new FormAuthenticator($identifiers, [
             'loginUrl' => '/base/users/login',

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -20,7 +20,6 @@ use Authentication\Authenticator\FormAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
-use Cake\Core\Configure;
 use Cake\Http\ServerRequestFactory;
 use RuntimeException;
 
@@ -182,7 +181,6 @@ class FormAuthenticatorTest extends TestCase
             'Authentication.Password',
         ]);
 
-        Configure::write('App.base', '/base');
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/users/login'],
             [],
@@ -271,7 +269,6 @@ class FormAuthenticatorTest extends TestCase
             'Authentication.Password',
         ]);
 
-        Configure::write('App.base', '/base');
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/users/login'],
             [],

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -24,7 +24,6 @@ use Authentication\Authenticator\UnauthenticatedException;
 use Authentication\IdentityInterface;
 use Authentication\Middleware\AuthenticationMiddleware;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
-use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Firebase\JWT\JWT;
@@ -572,12 +571,12 @@ class AuthenticationMiddlewareTest extends TestCase
      */
     public function testUnauthenticatedRedirectWithBase()
     {
-        Configure::write('App.base', '/base');
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/testpath'],
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
+        $request = $request->withAttribute('base', '/base');
         $handler = new TestRequestHandler(function ($request) {
             throw new UnauthenticatedException();
         });

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -24,9 +24,9 @@ use Authentication\Authenticator\UnauthenticatedException;
 use Authentication\IdentityInterface;
 use Authentication\Middleware\AuthenticationMiddleware;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
+use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
-use Cake\Http\Uri;
 use Firebase\JWT\JWT;
 use TestApp\Application;
 use TestApp\Http\TestRequestHandler;
@@ -572,14 +572,12 @@ class AuthenticationMiddlewareTest extends TestCase
      */
     public function testUnauthenticatedRedirectWithBase()
     {
+        Configure::write('App.base', '/base');
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/testpath'],
             [],
             ['username' => 'mariano', 'password' => 'password']
         );
-        $uri = $request->getUri();
-        $uri = new Uri($uri, '/base', $uri->webroot);
-        $request = $request->withUri($uri);
         $handler = new TestRequestHandler(function ($request) {
             throw new UnauthenticatedException();
         });

--- a/tests/TestCase/UrlChecker/DefaultUrlCheckerTest.php
+++ b/tests/TestCase/UrlChecker/DefaultUrlCheckerTest.php
@@ -18,8 +18,8 @@ namespace Authentication\Test\TestCase\UrlChecker;
 
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Authentication\UrlChecker\DefaultUrlChecker;
+use Cake\Core\Configure;
 use Cake\Http\ServerRequestFactory;
-use Cake\Http\Uri;
 
 /**
  * DefaultUrlCheckerTest
@@ -126,12 +126,11 @@ class DefaultUrlCheckerTest extends TestCase
      */
     public function testCheckBase()
     {
+        Configure::write('App.base', '/base');
         $checker = new DefaultUrlChecker();
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/users/login']
         );
-        $uri = new Uri($request->getUri(), '/base', '/base/');
-        $request = $request->withUri($uri);
 
         $result = $checker->check($request, 'http://localhost/base/users/login', [
             'checkFullUrl' => true,

--- a/tests/TestCase/UrlChecker/DefaultUrlCheckerTest.php
+++ b/tests/TestCase/UrlChecker/DefaultUrlCheckerTest.php
@@ -18,7 +18,6 @@ namespace Authentication\Test\TestCase\UrlChecker;
 
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
 use Authentication\UrlChecker\DefaultUrlChecker;
-use Cake\Core\Configure;
 use Cake\Http\ServerRequestFactory;
 
 /**
@@ -126,11 +125,11 @@ class DefaultUrlCheckerTest extends TestCase
      */
     public function testCheckBase()
     {
-        Configure::write('App.base', '/base');
         $checker = new DefaultUrlChecker();
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_URI' => '/users/login']
         );
+        $request = $request->withAttribute('base', '/base');
 
         $result = $checker->check($request, 'http://localhost/base/users/login', [
             'checkFullUrl' => true,


### PR DESCRIPTION
`Http\Uri` was dropped in https://github.com/cakephp/cakephp/pull/16859

But now since we don't have a wrapper class holding the `base` info the `DefaultUrlChecker` needed to be updated and use the config values instead. I don't know if this is the correct way right now but it was the first that came to my mind.