### PR TITLE
Update index.rst

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -6,7 +6,7 @@ Project's ROOT directory (where the **composer.json** file is located)
 
 .. code-block:: bash
 
-    php composer.phar require "cakephp/authentication:^2.0"
+    php composer.phar require cakephp/authentication
 
 Version 2 of the Authentication Plugin is compatible with CakePHP 4.
 


### PR DESCRIPTION
With "php composer.phar require "cakephp/authentication:^2.0""  result...

"Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - zendframework/zend-diactoros[2.0.0, ..., 2.2.1] require php ^7.1 -> your php version (8.2.3) does not satisfy that requirement.
    - cakephp/authentication 2.0.0 requires zendframework/zend-diactoros ^2.0 -> satisfiable by zendframework/zend-diactoros[2.0.0, ..., 2.2.1]. - Root composer.json requires cakephp/authentication 2.0 -> satisfiable by cakephp/authentication[2.0.0]."


BUT,  with the change continues the installation without problems.  (*Cakephp 4.4.11, windows 10, php 8.2.3)