### PR TITLE
Store only the original data in the impersonation session

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -373,7 +373,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
         $result = $service->impersonate(
             $controller->getRequest(),
             $controller->getResponse(),
-            $identity,
+            $identity->getOriginalData(),
             $impersonated
         );
 

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Authentication\Controller\Component;
 
 use ArrayAccess;
+use ArrayObject;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\Authenticator\ImpersonationInterface;
 use Authentication\Authenticator\PersistenceInterface;
@@ -370,7 +371,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
         }
         $impersonator = $identity->getOriginalData();
         if (!($impersonator instanceof ArrayAccess)) {
-            $impersonator = new ArrayAccess($impersonator);
+            $impersonator = new ArrayObject($impersonator);
         }
         $controller = $this->getController();
         /** @psalm-var array{request: \Cake\Http\ServerRequest, response: \Cake\Http\Response} $result */

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -368,12 +368,16 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
         if (!$identity) {
             throw new UnauthenticatedException('You must be logged in before impersonating a user.');
         }
+        $impersonator = $identity->getOriginalData();
+        if (!($impersonator instanceof ArrayAccess)) {
+            $impersonator = new ArrayAccess($impersonator);
+        }
         $controller = $this->getController();
         /** @psalm-var array{request: \Cake\Http\ServerRequest, response: \Cake\Http\Response} $result */
         $result = $service->impersonate(
             $controller->getRequest(),
             $controller->getResponse(),
-            $identity->getOriginalData(),
+            $impersonator,
             $impersonated
         );
 

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -578,6 +578,37 @@ class AuthenticationComponentTest extends TestCase
     }
 
     /**
+     * test that impersonate() can handle identities with array data within them.
+     *
+     * @return void
+     */
+    public function testImpersonateDecoratorIgnored()
+    {
+        $impersonator = ['username' => 'mariano'];
+        $impersonated = new ArrayObject(['username' => 'larry']);
+
+        $this->request->getSession()->write('Auth', $impersonator);
+        $this->service->authenticate($this->request);
+        $identity = new Identity($impersonator);
+        $request = $this->request
+            ->withAttribute('identity', $identity)
+            ->withAttribute('authentication', $this->service);
+        $controller = new Controller($request, $this->response);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $this->assertEquals($impersonator, $controller->getRequest()->getSession()->read('Auth'));
+        $this->assertNull($controller->getRequest()->getSession()->read('AuthImpersonate'));
+
+        $component->impersonate($impersonated);
+        $this->assertEquals($impersonated, $controller->getRequest()->getSession()->read('Auth'));
+        $this->assertEquals(new ArrayObject($impersonator), $controller->getRequest()->getSession()->read('AuthImpersonate'));
+
+        $component->stopImpersonating();
+        $this->assertNull($controller->getRequest()->getSession()->read('AuthImpersonate'));
+    }
+
+    /**
      * testImpersonateNoIdentity
      *
      * @return void

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -565,11 +565,16 @@ class AuthenticationComponentTest extends TestCase
         $controller = new Controller($request, $this->response);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
+
         $this->assertEquals($impersonator, $controller->getRequest()->getSession()->read('Auth'));
         $this->assertNull($controller->getRequest()->getSession()->read('AuthImpersonate'));
+
         $component->impersonate($impersonated);
         $this->assertEquals($impersonated, $controller->getRequest()->getSession()->read('Auth'));
-        $this->assertEquals($identity, $controller->getRequest()->getSession()->read('AuthImpersonate'));
+        $this->assertEquals($impersonator, $controller->getRequest()->getSession()->read('AuthImpersonate'));
+
+        $component->stopImpersonating();
+        $this->assertNull($controller->getRequest()->getSession()->read('AuthImpersonate'));
     }
 
     /**


### PR DESCRIPTION
Identity objects could contain closures by fetching the original data we can serialize into the session more consistently. It also ensures that when we next build an identity that a new decorator is created.

Fixes #606