### PR TITLE
Increase stability of cakephp requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "type": "cakephp-plugin",
     "homepage": "https://cakephp.org",
     "require": {
-        "cakephp/http": "dev-4.next",
+        "cakephp/http": "^4.5.0-RC1",
         "laminas/laminas-diactoros": "^2.2.2",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
@@ -18,7 +18,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "dev-4.next",
+        "cakephp/cakephp": "^4.5.0-RC1",
         "cakephp/cakephp-codesniffer": "^4.0",
         "firebase/php-jwt": "^6.2",
         "phpunit/phpunit": "^8.5 || ^9.3"


### PR DESCRIPTION
I ran into issues installing authentication alongside repl because of the dev- dependency. Also with RC1 out we can start requiring that instead of a dev revision.