### PR TITLE
3.next: add ability to set custom container instance 

### DIFF
--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -23,6 +23,7 @@ use Authentication\Authenticator\AuthenticationRequiredException;
 use Authentication\Authenticator\StatelessInterface;
 use Authentication\Authenticator\UnauthenticatedException;
 use Cake\Core\ContainerApplicationInterface;
+use Cake\Core\ContainerInterface;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Laminas\Diactoros\Stream;
@@ -44,15 +45,25 @@ class AuthenticationMiddleware implements MiddlewareInterface
     protected AuthenticationServiceInterface|AuthenticationServiceProviderInterface $subject;
 
     /**
+     * The container instance from the application
+     *
+     * @var \Cake\Core\ContainerInterface|null
+     */
+    protected ?ContainerInterface $container;
+
+    /**
      * Constructor
      *
      * @param \Authentication\AuthenticationServiceInterface|\Authentication\AuthenticationServiceProviderInterface $subject Authentication service or application instance.
+     * @param \Cake\Core\ContainerInterface|null $container The container instance from the application.
      * @throws \InvalidArgumentException When invalid subject has been passed.
      */
     public function __construct(
-        AuthenticationServiceInterface|AuthenticationServiceProviderInterface $subject
+        AuthenticationServiceInterface|AuthenticationServiceProviderInterface $subject,
+        ?ContainerInterface $container = null
     ) {
         $this->subject = $subject;
+        $this->container = $container;
     }
 
     /**
@@ -69,6 +80,8 @@ class AuthenticationMiddleware implements MiddlewareInterface
         if ($this->subject instanceof ContainerApplicationInterface) {
             $container = $this->subject->getContainer();
             $container->add(AuthenticationService::class, $service);
+        } elseif ($this->container) {
+            $this->container->add(AuthenticationService::class, $service);
         }
 
         try {

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -24,6 +24,7 @@ use Authentication\Authenticator\UnauthenticatedException;
 use Authentication\IdentityInterface;
 use Authentication\Middleware\AuthenticationMiddleware;
 use Authentication\Test\TestCase\AuthenticationTestCase as TestCase;
+use Cake\Core\Container;
 use Cake\Core\TestSuite\ContainerStubTrait;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -665,6 +666,27 @@ class AuthenticationMiddlewareTest extends TestCase
         $middleware->process($request, $handler);
 
         $container = $this->application->getContainer();
+        $this->assertInstanceOf(AuthenticationService::class, $container->get(AuthenticationService::class));
+    }
+
+    public function testMiddlewareInjectsServiceIntoDICCustomContainerInstance(): void
+    {
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/testpath'],
+            [],
+            ['username' => 'mariano', 'password' => 'password']
+        );
+        $handler = new TestRequestHandler();
+
+        $provider = $this->createMock(AuthenticationServiceProviderInterface::class);
+        $provider
+            ->method('getAuthenticationService')
+            ->willReturn($this->service);
+        $container = new Container();
+
+        $middleware = new AuthenticationMiddleware($provider, $container);
+        $middleware->process($request, $handler);
+
         $this->assertInstanceOf(AuthenticationService::class, $container->get(AuthenticationService::class));
     }
 }


### PR DESCRIPTION
Refs: https://github.com/cakephp/authorization/pull/278 & https://github.com/cakephp/authentication/issues/646. Forward-ported to `3.next`.