### PR TITLE
Add convenience method to get the identifier.

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -241,6 +241,16 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     }
 
     /**
+     * Get the identifier (primary key) of the identity.
+     *
+     * @return array|string|int|null
+     */
+    public function getIdentifier(): array|string|int|null
+    {
+        return $this->getIdentity()?->getIdentifier();
+    }
+
+    /**
      * Returns the identity used in the authentication attempt.
      *
      * @return \Authentication\IdentityInterface|null

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -143,6 +143,22 @@ class AuthenticationComponentTest extends TestCase
         $component->getAuthenticationService();
     }
 
+    public function testGetId(): void
+    {
+        $component = new AuthenticationComponent(new ComponentRegistry(new Controller($this->request)));
+        $this->assertNull($component->getIdentifier());
+
+        $request = $this->request
+            ->withAttribute('identity', $this->identity)
+            ->withAttribute('authentication', $this->service);
+
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $this->assertSame($component->getIdentifier(), $this->identity->getIdentifier());
+    }
+
     /**
      * testGetIdentity
      *


### PR DESCRIPTION
If you just need that id/identifier then using this new method would be more convenient than doing `$this->Authentication->getIdentityData('id')` (which can throw an exception) or doing `$this->Authentication->getIdentity()?->getIdentifier()`.