### PR TITLE
Fix example

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -165,7 +165,7 @@ like::
     {
         $result = $this->Authentication->getResult();
         // If the user is logged in send them away.
-        if ($result->isValid()) {
+        if ($result && $result->isValid()) {
             $target = $this->Authentication->getLoginRedirect() ?? '/home';
             return $this->redirect($target);
         }


### PR DESCRIPTION
The result is nullable
So PHPStan will throw error
```
  90     Cannot call method isValid() on Authentication\Authenticator\ResultInterface|null.       
         🪪  method.nonObject    
```