### PR TITLE
Clarify multi column

### DIFF
--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -38,9 +38,9 @@ Configuration options:
 
 -  **fields**: The fields for the lookup. Default is
    ``['username' => 'username', 'password' => 'password']``. You can
-   also set the table field name to an array. For e.g. using
+   also set the lookup field name to an array. For e.g. using
    ``['login' => ['username', 'email'], 'password' => 'password']``
-   will allow you to match value of either ``username`` or ``email`` columns based on your form posted ``login`` field content.
+   will allow you to match value of either ``username`` or ``email`` columns based on your (e.g. form posted) ``login`` field content.
 -  **resolver**: The identity resolver. Default is
    ``Authentication.Orm`` which uses CakePHP ORM.
 -  **passwordHasher**: Password hasher. Default is

--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -38,9 +38,9 @@ Configuration options:
 
 -  **fields**: The fields for the lookup. Default is
    ``['username' => 'username', 'password' => 'password']``. You can
-   also set the ``username`` to an array. For e.g. using
-   ``['username' => ['username', 'email'], 'password' => 'password']``
-   will allow you to match value of either username or email columns.
+   also set the field name to an array. For e.g. using
+   ``['login' => ['username', 'email'], 'password' => 'password']``
+   will allow you to match value of either username or email columns based on your form posted `login` field content.
 -  **resolver**: The identity resolver. Default is
    ``Authentication.Orm`` which uses CakePHP ORM.
 -  **passwordHasher**: Password hasher. Default is

--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -40,7 +40,7 @@ Configuration options:
    ``['username' => 'username', 'password' => 'password']``. You can
    also set the field name to an array. For e.g. using
    ``['login' => ['username', 'email'], 'password' => 'password']``
-   will allow you to match value of either username or email columns based on your form posted `login` field content.
+   will allow you to match value of either ``username`` or ``email`` columns based on your form posted ``login`` field content.
 -  **resolver**: The identity resolver. Default is
    ``Authentication.Orm`` which uses CakePHP ORM.
 -  **passwordHasher**: Password hasher. Default is

--- a/docs/en/identifiers.rst
+++ b/docs/en/identifiers.rst
@@ -38,7 +38,7 @@ Configuration options:
 
 -  **fields**: The fields for the lookup. Default is
    ``['username' => 'username', 'password' => 'password']``. You can
-   also set the field name to an array. For e.g. using
+   also set the table field name to an array. For e.g. using
    ``['login' => ['username', 'email'], 'password' => 'password']``
    will allow you to match value of either ``username`` or ``email`` columns based on your form posted ``login`` field content.
 -  **resolver**: The identity resolver. Default is


### PR DESCRIPTION
It is a bit hidden in general, maybe this makes it more clear for multi column as here the form field key would usually not be username, but sth more generic like "login".