### PR TITLE
Fix design flaw in auth process.

### DIFF
--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -85,6 +85,13 @@ class AuthenticationMiddleware implements MiddlewareInterface
 
         try {
             $result = $service->authenticate($request);
+            $authenticator = $service->getAuthenticationProvider();
+
+            if ($authenticator !== null && !$authenticator instanceof StatelessInterface) {
+                assert($result->getData() !== null);
+                $service->persistIdentity($request, new Response(), $result->getData());
+            }
+
         } catch (AuthenticationRequiredException $e) {
             $body = new Stream('php://memory', 'rw');
             $body->write($e->getBody());
@@ -104,16 +111,6 @@ class AuthenticationMiddleware implements MiddlewareInterface
 
         try {
             $response = $handler->handle($request);
-            $authenticator = $service->getAuthenticationProvider();
-
-            if ($authenticator !== null && !$authenticator instanceof StatelessInterface) {
-                /**
-                 * @psalm-suppress PossiblyNullArgument
-                 * @phpstan-ignore-next-line
-                 */
-                $return = $service->persistIdentity($request, $response, $result->getData());
-                $response = $return['response'];
-            }
         } catch (UnauthenticatedException $e) {
             $url = $service->getUnauthenticatedRedirectUrl($request);
             if ($url) {


### PR DESCRIPTION
This seems to resolve https://github.com/cakephp/authentication/issues/701

But I am not sure if thats the correct approach.
Either way, the rest of the stack must only be gone through once the persisting has happened again, otherwise the following code can be in a 5xx state.