### PR TITLE
Improve support for custom token prefixes.

### DIFF
--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -43,13 +43,11 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
      */
     protected function getToken(ServerRequestInterface $request): ?string
     {
-        $token = $this->getTokenFromHeader($request, $this->getConfig('header'));
-        if ($token === null) {
-            $token = $this->getTokenFromQuery($request, $this->getConfig('queryParam'));
-        }
+        $token = $this->getTokenFromHeader($request, $this->getConfig('header'))
+            ?? $this->getTokenFromQuery($request, $this->getConfig('queryParam'));
 
         $prefix = $this->getConfig('tokenPrefix');
-        if ($prefix !== null && is_string($token)) {
+        if ($prefix !== null && $token !== null) {
             return $this->stripTokenPrefix($token, $prefix);
         }
 
@@ -65,7 +63,7 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
      */
     protected function stripTokenPrefix(string $token, string $prefix): string
     {
-        return str_ireplace($prefix . ' ', '', $token);
+        return trim(str_ireplace($prefix, '', $token));
     }
 
     /**

--- a/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
@@ -132,6 +132,15 @@ class TokenAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
 
+        $requestWithHeaders = $this->request->withAddedHeader('X-Dipper-Auth', 'dipper_mariano');
+        $tokenAuth = new TokenAuthenticator($this->identifiers, [
+            'header' => 'X-Dipper-Auth',
+            'tokenPrefix' => 'dipper_',
+        ]);
+        $result = $tokenAuth->authenticate($requestWithHeaders);
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
+
         //invalid prefix
         $requestWithHeaders = $this->request->withAddedHeader('Token', 'bearer mariano');
         $tokenAuth = new TokenAuthenticator($this->identifiers, [


### PR DESCRIPTION
Any whitespace is now trimmed when extracting the token. Closes #688