### PR TITLE
Add allowUnauthenticatedAll() convenience wrapper

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -193,6 +193,23 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     /**
      * Set the list of actions that don't require an authentication identity to be present.
      *
+     * @return $this
+     */
+    public function allowUnauthenticatedAll()
+    {
+        $controller = $this->getController();
+        $methods = get_class_methods($controller);
+        $baseMethods = get_class_methods(get_parent_class($controller));
+
+        $actions = array_diff($methods, $baseMethods);
+        $this->unauthenticatedActions = array_values($actions);
+
+        return $this;
+    }
+
+    /**
+     * Set the list of actions that don't require an authentication identity to be present.
+     *
      * Actions not in this list will require an identity to be present. Any
      * valid identity will pass this constraint.
      *

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -199,7 +199,9 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     {
         $controller = $this->getController();
         $methods = get_class_methods($controller);
-        $baseMethods = get_class_methods(get_parent_class($controller));
+        /** @var class-string<\Cake\Controller\Controller> $parentClass */
+        $parentClass = get_parent_class($controller);
+        $baseMethods = get_class_methods($parentClass);
 
         $actions = array_diff($methods, $baseMethods);
         $this->unauthenticatedActions = array_values($actions);

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -33,6 +33,7 @@ use Cake\Http\ServerRequestFactory;
 use Cake\ORM\Entity;
 use InvalidArgumentException;
 use TestApp\Authentication\InvalidAuthenticationService;
+use TestApp\Controller\MyController;
 use UnexpectedValueException;
 
 /**
@@ -434,6 +435,24 @@ class AuthenticationComponentTest extends TestCase
             $controller->Authentication->getUnauthenticatedActions(),
             'Should contain unique set.',
         );
+    }
+
+    /**
+     * test unauthenticated actions methods
+     *
+     * @return void
+     */
+    public function testUnauthenticatedAll()
+    {
+        $request = $this->request
+            ->withParam('action', 'view')
+            ->withAttribute('authentication', $this->service);
+
+        $controller = new MyController($request);
+        $controller->loadComponent('Authentication.Authentication');
+
+        $controller->Authentication->allowUnauthenticatedAll();
+        $this->assertSame(['index', 'fooBar'], $controller->Authentication->getUnauthenticatedActions());
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/MyController.php
+++ b/tests/test_app/TestApp/Controller/MyController.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+
+class MyController extends Controller
+{
+    public function index()
+    {
+    }
+
+    public function fooBar()
+    {
+    }
+
+    protected function notMe()
+    {
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/cakephp/authentication/issues/645

setting the requireIdentity to false is not convenient for a specific controller