### PR TITLE
RFC Explore storing user as non object.

### DIFF
--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -15,10 +15,12 @@ declare(strict_types=1);
  */
 namespace Authentication\Authenticator;
 
+use App\Model\Entity\User;
 use ArrayAccess;
 use ArrayObject;
 use Authentication\Identifier\AbstractIdentifier;
 use Cake\Http\Exception\UnauthorizedException;
+use Cake\ORM\TableRegistry;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -59,6 +61,8 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
         /** @var \Cake\Http\Session $session */
         $session = $request->getAttribute('session');
         $user = $session->read($sessionKey);
+        $user = json_decode($user, true);
+        $user = TableRegistry::getTableLocator()->get('Users')->newEntity($user, ['validate' => false]);
 
         if (empty($user)) {
             return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
@@ -94,7 +98,8 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
 
         if (!$session->check($sessionKey)) {
             $session->renew();
-            $session->write($sessionKey, $identity);
+            $value = json_encode($identity);
+            $session->write($sessionKey, $value);
         }
 
         return [

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -61,8 +61,12 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
         /** @var \Cake\Http\Session $session */
         $session = $request->getAttribute('session');
         $user = $session->read($sessionKey);
-        $user = json_decode($user, true);
-        $user = TableRegistry::getTableLocator()->get('Users')->newEntity($user, ['validate' => false]);
+        if ($user) {
+            $userArray = json_decode($user, true);
+            $user = TableRegistry::getTableLocator()->get('Users')->newEntity($userArray, ['validate' => false]);
+            $user->id = $userArray['id'];
+            $user->setNew(false);
+        }
 
         if (empty($user)) {
             return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
@@ -98,7 +102,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
 
         if (!$session->check($sessionKey)) {
             $session->renew();
-            $value = json_encode($identity);
+            $value = json_encode($identity, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
             $session->write($sessionKey, $value);
         }
 

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
  */
 namespace Authentication\Authenticator;
 
-use App\Model\Entity\User;
 use ArrayAccess;
 use ArrayObject;
 use Authentication\Identifier\AbstractIdentifier;
@@ -33,7 +32,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
      * Default config for this object.
      * - `fields` The fields to use to verify a user by.
      * - `sessionKey` Session key.
-     * - `identify` Whether or not to identify user data stored in a session. This is
+     * - `identify` Whether to identify user data stored in a session. This is
      *   useful if you want to remotely end sessions that have a different password stored,
      *   or if your identification logic needs additional conditions before a user can login.
      *
@@ -47,6 +46,7 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
         'impersonateSessionKey' => 'AuthImpersonate',
         'identify' => false,
         'identityAttribute' => 'identity',
+        'serialize' => true,
     ];
 
     /**
@@ -62,10 +62,18 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
         $session = $request->getAttribute('session');
         $user = $session->read($sessionKey);
         if ($user) {
-            $userArray = json_decode($user, true);
-            $user = TableRegistry::getTableLocator()->get('Users')->newEntity($userArray, ['validate' => false]);
-            $user->id = $userArray['id'];
-            $user->setNew(false);
+            $userArray = $user;
+            if (is_string($userArray)) {
+                $userArray = static::decode($userArray);
+            }
+            if (!$userArray instanceof ArrayObject) {
+                /** @var \Cake\ORM\Entity $user */
+                $user = TableRegistry::getTableLocator()->get('Users')->newEntity($userArray, ['validate' => false]);
+                $user->id = $userArray['id'];
+                $user->setNew(false);
+            } else {
+                $user = $userArray;
+            }
         }
 
         if (empty($user)) {
@@ -102,8 +110,10 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
 
         if (!$session->check($sessionKey)) {
             $session->renew();
-            $value = json_encode($identity, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
-            $session->write($sessionKey, $value);
+            if ($this->getConfig('serialize')) {
+                $identity = static::encode($identity);
+            }
+            $session->write($sessionKey, $identity);
         }
 
         return [
@@ -203,5 +213,24 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
         $session = $request->getAttribute('session');
 
         return $session->check($impersonateSessionKey);
+    }
+
+    /**
+     * @param \ArrayAccess|array $user
+     * @return string
+     * @throws \JsonException
+     */
+    public static function encode(ArrayAccess|array $user): string
+    {
+        return json_encode($user, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param string $user
+     * @return array
+     */
+    public static function decode(string $user): array
+    {
+        return json_decode($user, true);
     }
 }

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -388,6 +388,52 @@ class AuthenticationServiceTest extends TestCase
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
 
         $this->assertSame(
+            '{"username":"florian"}',
+            $result['request']->getAttribute('session')->read('Auth'),
+        );
+
+        $identity = $result['request']->getAttribute('identity');
+        $this->assertInstanceOf(IdentityInterface::class, $identity);
+        $this->assertEquals($data, $identity->getOriginalData());
+    }
+
+    /**
+     * testPersistIdentity
+     *
+     * @return void
+     */
+    public function testPersistIdentitySerializeFalse()
+    {
+        $service = new AuthenticationService([
+            'identifiers' => [
+                'Authentication.Password',
+            ],
+            'authenticators' => [
+                'Authentication.Session' => [
+                    'serialize' => false,
+                ],
+                'Authentication.Form',
+            ],
+        ]);
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/'],
+        );
+
+        $response = new Response();
+
+        $this->assertEmpty($request->getAttribute('identity'));
+
+        $data = new ArrayObject(['username' => 'florian']);
+        $result = $service->persistIdentity($request, $response, $data);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('request', $result);
+        $this->assertArrayHasKey('response', $result);
+        $this->assertInstanceOf(RequestInterface::class, $result['request']);
+        $this->assertInstanceOf(ResponseInterface::class, $result['response']);
+
+        $this->assertSame(
             'florian',
             $result['request']->getAttribute('session')->read('Auth.username'),
         );
@@ -434,8 +480,8 @@ class AuthenticationServiceTest extends TestCase
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
 
         $this->assertSame(
-            'florian',
-            $result['request']->getAttribute('session')->read('Auth.username'),
+            '{"username":"florian"}',
+            $result['request']->getAttribute('session')->read('Auth'),
         );
 
         $identity = $result['request']->getAttribute('customIdentity');
@@ -482,8 +528,8 @@ class AuthenticationServiceTest extends TestCase
         $this->assertInstanceOf(ResponseInterface::class, $result['response']);
 
         $this->assertSame(
-            'florian',
-            $result['request']->getAttribute('session')->read('Auth.username'),
+            '{"username":"florian"}',
+            $result['request']->getAttribute('session')->read('Auth'),
         );
 
         $identity = $result['request']->getAttribute('customIdentity');

--- a/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SessionAuthenticatorTest.php
@@ -202,7 +202,7 @@ class SessionAuthenticatorTest extends TestCase
         $this->sessionMock
             ->expects($this->once())
             ->method('write')
-            ->with('Auth', $data);
+            ->with('Auth', SessionAuthenticator::encode($data));
 
         $result = $authenticator->persistIdentity($request, $response, $data);
         $this->assertIsArray($result);

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -20,6 +20,7 @@ use ArrayObject;
 use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\Authenticator\AuthenticatorInterface;
+use Authentication\Authenticator\SessionAuthenticator;
 use Authentication\Authenticator\UnauthenticatedException;
 use Authentication\Controller\Component\AuthenticationComponent;
 use Authentication\Identity;
@@ -255,8 +256,8 @@ class AuthenticationComponentTest extends TestCase
         $result = $component->getIdentity();
         $this->assertSame($this->identityData, $result->getOriginalData());
         $this->assertSame(
-            $this->identityData->username,
-            $request->getSession()->read('Auth.username'),
+            '{"username":"florian","profession":"developer"}',
+            $request->getSession()->read('Auth'),
             'Session should be updated.',
         );
 
@@ -267,8 +268,8 @@ class AuthenticationComponentTest extends TestCase
         $result = $component->getIdentity();
         $this->assertSame($newIdentity, $result->getOriginalData());
         $this->assertSame(
-            $newIdentity->username,
-            $request->getSession()->read('Auth.username'),
+            '{"username":"jessie"}',
+            $request->getSession()->read('Auth'),
             'Session should be updated.',
         );
     }
@@ -568,17 +569,17 @@ class AuthenticationComponentTest extends TestCase
     {
         $impersonator = new ArrayObject(['username' => 'mariano']);
         $impersonated = new ArrayObject(['username' => 'larry']);
-        $this->request->getSession()->write('Auth', $impersonator);
+        $this->request->getSession()->write('Auth', SessionAuthenticator::encode($impersonator));
         $this->service->authenticate($this->request);
         $identity = new Identity($impersonator);
         $request = $this->request
             ->withAttribute('identity', $identity)
             ->withAttribute('authentication', $this->service);
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
-        $this->assertEquals($impersonator, $controller->getRequest()->getSession()->read('Auth'));
+        $this->assertEquals(SessionAuthenticator::encode($impersonator), $controller->getRequest()->getSession()->read('Auth'));
         $this->assertNull($controller->getRequest()->getSession()->read('AuthImpersonate'));
 
         $component->impersonate($impersonated);
@@ -605,7 +606,7 @@ class AuthenticationComponentTest extends TestCase
         $request = $this->request
             ->withAttribute('identity', $identity)
             ->withAttribute('authentication', $this->service);
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -630,7 +631,7 @@ class AuthenticationComponentTest extends TestCase
         $impersonated = new ArrayObject(['username' => 'larry']);
         $request = $this->request
             ->withAttribute('authentication', $this->service);
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
         $this->expectException(UnauthenticatedException::class);
@@ -659,7 +660,7 @@ class AuthenticationComponentTest extends TestCase
         $request = $this->request
             ->withAttribute('identity', $identity)
             ->withAttribute('authentication', $service);
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
         $this->expectException(UnexpectedValueException::class);
@@ -676,18 +677,18 @@ class AuthenticationComponentTest extends TestCase
     {
         $impersonator = new ArrayObject(['username' => 'mariano']);
         $impersonated = new ArrayObject(['username' => 'larry']);
-        $this->request->getSession()->write('Auth', $impersonated);
-        $this->request->getSession()->write('AuthImpersonate', $impersonator);
+        $this->request->getSession()->write('Auth', SessionAuthenticator::encode($impersonated));
+        $this->request->getSession()->write('AuthImpersonate', SessionAuthenticator::encode($impersonator));
         $this->service->authenticate($this->request);
         $request = $this->request->withAttribute('authentication', $this->service);
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
-        $this->assertEquals($impersonator, $controller->getRequest()->getSession()->read('AuthImpersonate'));
-        $this->assertEquals($impersonated, $controller->getRequest()->getSession()->read('Auth'));
+        $this->assertEquals(SessionAuthenticator::encode($impersonator), $controller->getRequest()->getSession()->read('AuthImpersonate'));
+        $this->assertEquals(SessionAuthenticator::encode($impersonated), $controller->getRequest()->getSession()->read('Auth'));
         $component->stopImpersonating();
         $this->assertNull($controller->getRequest()->getSession()->read('AuthImpersonate'));
-        $this->assertEquals($impersonator, $controller->getRequest()->getSession()->read('Auth'));
+        $this->assertEquals(SessionAuthenticator::encode($impersonator), $controller->getRequest()->getSession()->read('Auth'));
     }
 
     /**
@@ -710,7 +711,7 @@ class AuthenticationComponentTest extends TestCase
         $request = $this->request
             ->withAttribute('identity', $identity)
             ->withAttribute('authentication', $service);
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
         $this->expectException(UnexpectedValueException::class);
@@ -727,13 +728,13 @@ class AuthenticationComponentTest extends TestCase
     {
         $impersonator = new ArrayObject(['username' => 'mariano']);
         $impersonated = new ArrayObject(['username' => 'larry']);
-        $this->request->getSession()->write('Auth', $impersonated);
-        $this->request->getSession()->write('AuthImpersonate', $impersonator);
+        $this->request->getSession()->write('Auth', SessionAuthenticator::encode($impersonated));
+        $this->request->getSession()->write('AuthImpersonate', SessionAuthenticator::encode($impersonator));
         $this->service->authenticate($this->request);
         $request = $this->request
             ->withAttribute('authentication', $this->service)
             ->withAttribute('identity', new Identity($impersonated));
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -757,7 +758,7 @@ class AuthenticationComponentTest extends TestCase
         $request = $this->request
             ->withAttribute('authentication', $service)
             ->withAttribute('identity', new Identity($user));
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 
@@ -775,10 +776,10 @@ class AuthenticationComponentTest extends TestCase
     public function testIsImpersonatingNotImpersonating()
     {
         $user = new ArrayObject(['username' => 'mariano']);
-        $this->request->getSession()->write('Auth', $user);
+        $this->request->getSession()->write('Auth', SessionAuthenticator::encode($user));
         $this->service->authenticate($this->request);
         $request = $this->request->withAttribute('authentication', $this->service);
-        $controller = new Controller($request, $this->response);
+        $controller = new Controller($request);
         $registry = new ComponentRegistry($controller);
         $component = new AuthenticationComponent($registry);
 

--- a/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AuthenticationMiddlewareTest.php
@@ -20,6 +20,7 @@ use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\AuthenticationServiceProviderInterface;
 use Authentication\Authenticator\ResultInterface;
+use Authentication\Authenticator\SessionAuthenticator;
 use Authentication\Authenticator\UnauthenticatedException;
 use Authentication\IdentityInterface;
 use Authentication\Middleware\AuthenticationMiddleware;
@@ -290,7 +291,8 @@ class AuthenticationMiddlewareTest extends TestCase
         $this->assertTrue($this->service->getResult()->isValid());
 
         // After the middleware is done session should be populated
-        $this->assertSame('mariano', $request->getAttribute('session')->read('Auth.username'));
+        $user = SessionAuthenticator::decode($request->getAttribute('session')->read('Auth'));
+        $this->assertSame('mariano', $user['username']);
     }
 
     /**


### PR DESCRIPTION
I would be open to feedback on how this could be accomplished.
Being able to store the user entity as array or better yet JSON is much more robust.

Any change in the object or its children (created/modified DateTime), related models, ..., role enum, ...) will all cause an immediate invalidation right now.
Storing them in their agnostic form and then rebuilding seems much more logical to me.

Currently it would need to get a transformer passed in though, as it knows too much about the ORM/model/entity.
Right now a "modelClass" defaulting to "Users" could suffice.


For me in a first test this seems to properly populate again:
```php
object(App\Model\Entity\User) id:1 {
  'first_name' => 'Admin'
  'role' => object(App\Model\Enum\UserRole) id:1 {
    name => 'Admin'
    value => 'admin'
  }
  'email' => 'admin@example.com'
  'email_verified_at' => object(Cake\I18n\DateTime) id:2 {
    'hasFixedNow' => false
    'time' => '2025-04-08 00:00:00.000000'
    'timezone' => 'UTC'
  }
  'remember_token' => null
  'company_id' => (int) 1
  'last_login' => object(Cake\I18n\DateTime) id:3 {
    'hasFixedNow' => false
    'time' => '2025-04-16 22:03:51.000000'
    'timezone' => 'UTC'
  }
  'created' => object(Cake\I18n\DateTime) id:4 {
    'hasFixedNow' => false
    'time' => '2025-04-08 00:00:00.000000'
    'timezone' => 'UTC'
  }
  'modified' => object(Cake\I18n\DateTime) id:5 {
    'hasFixedNow' => false
    'time' => '2025-04-09 10:41:11.000000'
    'timezone' => 'UTC'
  }
  'phone' => null
  'last_name' => 'Tester'
```

I put my idea behind a feature flag serialize true/false
this way it could be made BC

