### PR TITLE
Add PHP min version for user and IDE.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "docs": "https://book.cakephp.org/authentication/3/en/"
     },
     "require": {
+        "php": ">=8.1",
         "cakephp/http": "^5.0",
         "laminas/laminas-diactoros": "^3.0",
         "psr/http-client": "^1.0",

--- a/src/Identifier/Ldap/AdapterInterface.php
+++ b/src/Identifier/Ldap/AdapterInterface.php
@@ -32,7 +32,7 @@ interface AdapterInterface
      *
      * @param string $host Hostname
      * @param int $port Port
-     * @param array $options Additional options
+     * @param array<string, mixed> $options Additional options
      * @return void
      */
     public function connect(string $host, int $port, array $options): void;

--- a/src/Identifier/Ldap/AdapterInterface.php
+++ b/src/Identifier/Ldap/AdapterInterface.php
@@ -32,7 +32,7 @@ interface AdapterInterface
      *
      * @param string $host Hostname
      * @param int $port Port
-     * @param array<string, mixed> $options Additional options
+     * @param array $options Additional options
      * @return void
      */
     public function connect(string $host, int $port, array $options): void;

--- a/src/Identifier/Ldap/ExtensionAdapter.php
+++ b/src/Identifier/Ldap/ExtensionAdapter.php
@@ -89,7 +89,7 @@ class ExtensionAdapter implements AdapterInterface
      *
      * @param string $host Hostname
      * @param int $port Port
-     * @param array<string, mixed> $options Additional LDAP options
+     * @param array $options Additional LDAP options
      * @return void
      */
     public function connect(string $host, int $port, array $options): void
@@ -110,7 +110,7 @@ class ExtensionAdapter implements AdapterInterface
         $this->_unsetErrorHandler();
 
         foreach ($options as $option => $value) {
-            $this->setOption($option, $value);
+            $this->setOption((int)$option, $value);
         }
     }
 

--- a/src/Identifier/Ldap/ExtensionAdapter.php
+++ b/src/Identifier/Ldap/ExtensionAdapter.php
@@ -89,7 +89,7 @@ class ExtensionAdapter implements AdapterInterface
      *
      * @param string $host Hostname
      * @param int $port Port
-     * @param array $options Additonal LDAP options
+     * @param array<string, mixed> $options Additional LDAP options
      * @return void
      */
     public function connect(string $host, int $port, array $options): void

--- a/src/UrlChecker/DefaultUrlChecker.php
+++ b/src/UrlChecker/DefaultUrlChecker.php
@@ -69,7 +69,7 @@ class DefaultUrlChecker implements UrlCheckerInterface
      * method and inject additional options without the need to use the
      * MergeVarsTrait.
      *
-     * @param array $options Options to merge in
+     * @param array<string, mixed> $options Options to merge in
      * @return array
      */
     protected function _mergeDefaultOptions(array $options): array
@@ -80,7 +80,7 @@ class DefaultUrlChecker implements UrlCheckerInterface
     /**
      * Gets the checker function name or a callback
      *
-     * @param array $options Array of options
+     * @param array<string, mixed> $options Array of options
      * @return callable
      */
     protected function _getChecker(array $options): callable

--- a/src/UrlChecker/UrlCheckerInterface.php
+++ b/src/UrlChecker/UrlCheckerInterface.php
@@ -28,7 +28,7 @@ interface UrlCheckerInterface
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request Server Request
      * @param array|string $loginUrls Login URL string or array of URLs
-     * @param array $options Array of options
+     * @param array<string, mixed> $options Array of options
      * @return bool
      */
     public function check(ServerRequestInterface $request, array|string $loginUrls, array $options = []): bool;


### PR DESCRIPTION
Best practice.
Without it my IDE (latest phpstorm) guesses 8.0, and it seems hard to adjust apparently.
Also more clear for devs.

In sync with https://github.com/cakephp/authorization/blob/ff4730478b6b24d40a10ec63e05ab2aa51c98f93/composer.json#L26 and the other plugins