### PR TITLE
allow unauthenticatedRedirect as array cake style.

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -85,12 +85,12 @@ define the ``AuthenticationService`` it wants to use. Add the following method t
 
         // Define where users should be redirected to when they are not authenticated
         $service->setConfig([
-            'unauthenticatedRedirect' => Router::url([
+            'unauthenticatedRedirect' => [
                     'prefix' => false,
-                    'plugin' => null,
+                    'plugin' => false,
                     'controller' => 'Users',
                     'action' => 'login',
-            ]),
+            ],
             'queryParam' => 'redirect',
         ]);
 

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -373,7 +373,7 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
         if ($target === null) {
             return null;
         }
-        if (is_array($target)) {
+        if (is_array($target) && class_exists(Router::class)) {
             $target = Router::url($target);
         }
         if ($param === null) {

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -26,6 +26,7 @@ use Authentication\Authenticator\StatelessInterface;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Identifier\IdentifierInterface;
 use Cake\Core\InstanceConfigTrait;
+use Cake\Routing\Router;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -371,6 +372,9 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
         $target = $this->getConfig('unauthenticatedRedirect');
         if ($target === null) {
             return null;
+        }
+        if (is_array($target)) {
+            $target = Router::url($target);
         }
         if ($param === null) {
             return $target;

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -32,6 +32,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\I18n\DateTime;
+use Cake\Routing\Router;
 use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -816,6 +817,30 @@ class AuthenticationServiceTest extends TestCase
             '/users/login?foo=bar&redirect=%2Fsecrets#fragment',
             $service->getUnauthenticatedRedirectUrl($request),
         );
+    }
+
+    public function testGetUnauthenticatedRedirectUrlAsArray()
+    {
+        Router::fullBaseUrl('http://localhost');
+
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect(
+            '/login',
+            ['controller' => 'Users', 'action' => 'login'],
+            ['_name' => 'login'],
+        );
+
+        $service = new AuthenticationService();
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/secrets'],
+        );
+        $service->setConfig('unauthenticatedRedirect', [
+            'prefix' => false,
+            'plugin' => false,
+            'controller' => 'Users',
+            'action' => 'login',
+        ]);
+        $this->assertSame('/login', $service->getUnauthenticatedRedirectUrl($request));
     }
 
     public function testGetUnauthenticatedRedirectUrlWithBasePath()


### PR DESCRIPTION
Seemed weird to me that in normal Cake context in a Cake plugin the URL cannot be defined in normal array style
if array, Router::url() is usually also used in other parts, and always allowed as alternative to strings.