### PR TITLE
Link to impersonation cookbook article

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -377,6 +377,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      * @param \ArrayAccess $impersonated User impersonated
      * @return $this
      * @throws \Exception
+     * @see https://book.cakephp.org/authentication/3/en/impersonation.html
      */
     public function impersonate(ArrayAccess $impersonated)
     {
@@ -414,6 +415,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      *
      * @return $this
      * @throws \Exception
+     * @see https://book.cakephp.org/authentication/3/en/impersonation.html
      */
     public function stopImpersonating()
     {
@@ -442,6 +444,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      *
      * @return bool
      * @throws \Exception
+     * @see https://book.cakephp.org/authentication/3/en/impersonation.html
      */
     public function isImpersonating(): bool
     {
@@ -462,6 +465,7 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      *
      * @return \Authentication\Authenticator\ImpersonationInterface
      * @throws \Exception
+     * @see https://book.cakephp.org/authentication/3/en/impersonation.html
      */
     protected function getImpersonationAuthenticationService(): ImpersonationInterface
     {


### PR DESCRIPTION
I war reading [DerEuroMark's recent article about his TinyAuth plugin](https://www.dereuromark.de/2025/04/17/tinyauth-and-cakephp-authorization-plugin/), which mentions the impersonation feature built into the Authorization plugin and wanted to look up the API. After that, I wanted to look up the documentation for that feature.

Having the links in the API to the docs helps devs to find what they look for.