### PR TITLE
Fix token auth prefix removal.

### DIFF
--- a/src/Authenticator/TokenAuthenticator.php
+++ b/src/Authenticator/TokenAuthenticator.php
@@ -63,7 +63,12 @@ class TokenAuthenticator extends AbstractAuthenticator implements StatelessInter
      */
     protected function stripTokenPrefix(string $token, string $prefix): string
     {
-        return trim(str_ireplace($prefix, '', $token));
+        $prefixLength = mb_strlen($prefix);
+        if (mb_substr(mb_strtolower($token), 0, $prefixLength) === mb_strtolower($prefix)) {
+            $token = mb_substr($token, $prefixLength);
+        }
+
+        return trim($token);
     }
 
     /**

--- a/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
@@ -150,6 +150,16 @@ class TokenAuthenticatorTest extends TestCase
         $result = $tokenAuth->authenticate($requestWithHeaders);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+
+        // should not modify in between
+        $requestWithHeaders = $this->request->withAddedHeader('X-Dipper-Auth', 'auth-token-13');
+        $tokenAuth = new TokenAuthenticator($this->identifiers, [
+            'header' => 'X-Dipper-Auth',
+            'tokenPrefix' => 'token_',
+        ]);
+        $result = $tokenAuth->authenticate($requestWithHeaders);
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
     }
 
     /**

--- a/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
@@ -151,11 +151,11 @@ class TokenAuthenticatorTest extends TestCase
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
 
-        // should not modify in between
-        $requestWithHeaders = $this->request->withAddedHeader('X-Dipper-Auth', 'token_auth-token-13');
+        // should not remove prefix from token
+        $requestWithHeaders = $this->request->withAddedHeader('X-Dipper-Auth', 'mari mariano');
         $tokenAuth = new TokenAuthenticator($this->identifiers, [
             'header' => 'X-Dipper-Auth',
-            'tokenPrefix' => 'token_',
+            'tokenPrefix' => 'mari',
         ]);
         $result = $tokenAuth->authenticate($requestWithHeaders);
         $this->assertInstanceOf(Result::class, $result);

--- a/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TokenAuthenticatorTest.php
@@ -152,7 +152,7 @@ class TokenAuthenticatorTest extends TestCase
         $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
 
         // should not modify in between
-        $requestWithHeaders = $this->request->withAddedHeader('X-Dipper-Auth', 'auth-token-13');
+        $requestWithHeaders = $this->request->withAddedHeader('X-Dipper-Auth', 'token_auth-token-13');
         $tokenAuth = new TokenAuthenticator($this->identifiers, [
             'header' => 'X-Dipper-Auth',
             'tokenPrefix' => 'token_',


### PR DESCRIPTION
Resolves https://github.com/cakephp/authentication/issues/720

Does this work?

However, the test case doesnt quite seem right, it fails.
Do you have an idea for a correct test case?