### PR TITLE
Error: Supplied key param cannot be coerced into a public key

### DIFF
--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -141,7 +141,7 @@ Add the following to your ``Application`` class::
         // ...
         $service->loadIdentifier('Authentication.JwtSubject');
         $service->loadAuthenticator('Authentication.Jwt', [
-            'secretKey' => file_get_contents(CONFIG . '/jwt.key'),
+            'secretKey' => file_get_contents(CONFIG . '/jwt.pem'),
             'algorithm' => 'RS256',
             'returnPayload' => false
         ]);


### PR DESCRIPTION
The secretKey in loadAuthenticator should be the public key (jwt.pem).

Using the private key I get this error:

![image](https://github.com/user-attachments/assets/e3eb1a0d-4478-4a07-aa04-61ab742402ca)

While on this topic, should this property be called secretKey? It causes some confusion to whether its the public or private key.