### PR TITLE
Fix argument type for AuthenticationComponent::setIdentity().

### DIFF
--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -300,10 +300,10 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      * is cleared and then set to ensure that privilege escalation
      * and de-escalation include side effects like session rotation.
      *
-     * @param \ArrayAccess $identity Identity data to persist.
+     * @param \ArrayAccess|array $identity Identity data to persist.
      * @return $this
      */
-    public function setIdentity(ArrayAccess $identity)
+    public function setIdentity(ArrayAccess|array $identity)
     {
         $controller = $this->getController();
         $service = $this->getAuthenticationService();

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -214,6 +214,11 @@ class AuthenticationComponentTest extends TestCase
         $component->setIdentity($this->identityData);
         $result = $component->getIdentity();
         $this->assertSame($this->identityData, $result->getOriginalData());
+
+        $identityData = ['id' => 99];
+        $component->setIdentity($identityData);
+        $result = $component->getIdentity();
+        $this->assertSame($identityData, $result->getOriginalData());
     }
 
     /**


### PR DESCRIPTION
It should accept an array as AuthenticationService::persistIdentity() accepts an array too.