### PR TITLE
Remove deprecationWarning for creating an Authenticator without Identifier

### DIFF
--- a/src/Authenticator/AuthenticatorCollection.php
+++ b/src/Authenticator/AuthenticatorCollection.php
@@ -67,11 +67,6 @@ class AuthenticatorCollection extends AbstractCollection
         if (is_string($class)) {
             if (!empty($config['identifier'])) {
                 $this->_identifiers = new IdentifierCollection((array)$config['identifier']);
-            } else {
-                deprecationWarning(
-                    '3.3.0',
-                    'loadIdentifier() usage is deprecated. Directly pass `\'identifier\'` config to the Authenticator.',
-                );
             }
 
             return new $class($this->_identifiers, $config);


### PR DESCRIPTION
This should not give a deprecationWarning as not having an identifier should be a supported configuration for certain identifiers (e.g. Session).

However, there probably should be a check somewhere else if loadIdentifier() is being used.