### PR TITLE
Update password-hashers.rst

### DIFF
--- a/docs/en/password-hashers.rst
+++ b/docs/en/password-hashers.rst
@@ -47,7 +47,8 @@ fallback hasher as follows::
             'passwordHasher' => [
                 'className' => 'Authentication.Fallback',
                 'hashers' => [
-                    'Authentication.Default' => [
+                    'Authentication.Default',
+                    [
                         'className' => 'Authentication.Legacy',
                         'hashType' => 'md5',
                         'salt' => false, // turn off default usage of salt
@@ -68,8 +69,7 @@ password needs to be upgraded::
 
        // regardless of POST or GET, redirect if user is logged in
        if ($result->isValid()) {
-           // Assuming you are using the `Password` identifier.
-           if ($authentication->identifiers()->get('Password')->needsPasswordRehash()) {
+           if ($authentication->getIdentificationProvider()->needsPasswordRehash()) {
                // Rehash happens on save.
                $user = $this->Users->get($authentication->getIdentity()->getIdentifier());
                $user->password = $this->request->getData('password');


### PR DESCRIPTION
Fix problems with examples when using the preferred 3.3.x configuration pattern.

Fixes 2 problems:
1) fallback authentication didn't work (typo in config)
2) login action failed with:
[Cake\Core\Exception\CakeException] Unknown object `Password`. in vendor/cakephp/cakephp/src/Core/ObjectRegistry.php on line 238
