### PR TITLE
Don't populate IdentifierCollection errors with empty nested arrays

### DIFF
--- a/src/Identifier/IdentifierCollection.php
+++ b/src/Identifier/IdentifierCollection.php
@@ -56,7 +56,11 @@ class IdentifierCollection extends AbstractCollection implements IdentifierInter
 
                 return $result;
             }
-            $this->_errors[$name] = $identifier->getErrors();
+
+            $errors = $identifier->getErrors();
+            if ($errors) {
+                $this->_errors[$name] = $identifier->getErrors();
+            }
         }
 
         $this->_successfulIdentifier = null;

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -112,6 +112,27 @@ class FormAuthenticatorTest extends TestCase
         $this->assertEquals([0 => 'Login credentials not found'], $result->getErrors());
     }
 
+    public function testIdentityNotFound()
+    {
+        $identifiers = new IdentifierCollection([
+           'Authentication.Password',
+        ]);
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/users/does-not-match'],
+            [],
+            ['username' => 'non-existent', 'password' => 'password'],
+        );
+
+        $form = new FormAuthenticator($identifiers);
+
+        $result = $form->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::FAILURE_IDENTITY_NOT_FOUND, $result->getStatus());
+        $this->assertSame([], $result->getErrors());
+    }
+
     /**
      * testSingleLoginUrlMismatch
      *


### PR DESCRIPTION
Before this fix using `$result->getErrors()` would return `['Password' => []]` when using form authenticate with a non existent user.