### PR TITLE
Set the redirect query param only for GET requests.

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -383,14 +383,20 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
      */
     public function getUnauthenticatedRedirectUrl(ServerRequestInterface $request): ?string
     {
-        $param = $this->getConfig('queryParam');
         $target = $this->getConfig('unauthenticatedRedirect');
         if ($target === null) {
             return null;
         }
+
         if (is_array($target) && class_exists(Router::class)) {
             $target = Router::url($target);
         }
+
+        if ($request->getMethod() !== 'GET') {
+            return $target;
+        }
+
+        $param = $this->getConfig('queryParam');
         if ($param === null) {
             return $target;
         }

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -847,6 +847,22 @@ class AuthenticationServiceTest extends TestCase
         );
     }
 
+    public function testGetUnauthenticatedRedirectUrlForPost()
+    {
+        $service = new AuthenticationService();
+        $service->setConfig('unauthenticatedRedirect', '/users/login');
+        $service->setConfig('queryParam', 'redirect');
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/secrets', 'REQUEST_METHOD' => 'POST'],
+        );
+        $this->assertSame(
+            '/users/login',
+            $service->getUnauthenticatedRedirectUrl($request),
+            'Redirect query param should be only set for GET requests',
+        );
+    }
+
     public function testGetUnauthenticatedRedirectUrlAsArray()
     {
         Router::fullBaseUrl('http://localhost');


### PR DESCRIPTION
Currently if the session expires for a logged in user and they click on a (post) link for "Delete" action, after login they get redirected to the delete action with a GET request, resulting in an exception since that action is only accessible with POST/DELETE request.