### PR TITLE
Add default TokenIdentifier for PrimaryKeySessionAuthenticator

### DIFF
--- a/docs/en/authenticators.rst
+++ b/docs/en/authenticators.rst
@@ -37,22 +37,33 @@ It also helps to avoid session invalidation.
 Session itself stores the entity object including nested objects like DateTime or enums.
 With only the ID stored, the invalidation due to objects being modified will also dissolve.
 
-Make sure to match this with a Token identifier with ``key``/``id`` keys::
+A default ``TokenIdentifier`` is provided that looks up users by their ``id`` field,
+so minimal configuration is required::
+
+    $service->loadAuthenticator('Authentication.PrimaryKeySession');
+
+Configuration options:
+
+-  **idField**: The field in the database table to look up. Default is ``id``.
+-  **identifierKey**: The key used to store/retrieve the primary key from session data.
+   Default is ``key``.
+
+For custom lookup fields, the ``idField`` and ``identifierKey`` options propagate
+to the default identifier automatically::
+
+    $service->loadAuthenticator('Authentication.PrimaryKeySession', [
+        'idField' => 'uuid',
+    ]);
+
+You can also provide a fully custom identifier configuration if needed::
 
     $service->loadAuthenticator('Authentication.PrimaryKeySession', [
         'identifier' => [
             'Authentication.Token' => [
-                'tokenField' => 'id', // lookup for resolver and DB table
-                'dataField' => 'key', // incoming data from authenticator
+                'tokenField' => 'id',
+                'dataField' => 'key',
                 'resolver' => 'Authentication.Orm',
             ],
-        ],
-        'urlChecker' => 'Authentication.CakeRouter',
-        'loginUrl' => [
-            'prefix' => false,
-            'plugin' => false,
-            'controller' => 'Users',
-            'action' => 'login',
         ],
     ]);
 

--- a/src/Authenticator/PrimaryKeySessionAuthenticator.php
+++ b/src/Authenticator/PrimaryKeySessionAuthenticator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Authentication\Authenticator;
 
 use ArrayAccess;
+use Authentication\Identifier\IdentifierFactory;
 use Authentication\Identifier\IdentifierInterface;
 use Cake\Http\Exception\UnauthorizedException;
 use Psr\Http\Message\ResponseInterface;
@@ -11,21 +12,87 @@ use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Session Authenticator with only ID
+ *
+ * This authenticator stores only the user's primary key in the session,
+ * and looks up the full user record from the database on each request.
+ *
+ * By default, it uses a TokenIdentifier configured to look up users by
+ * their `id` field. This works out of the box for most applications:
+ *
+ * ```php
+ * $service->loadAuthenticator('Authentication.PrimaryKeySession');
+ * ```
+ *
+ * You can customize the identifier configuration if needed:
+ *
+ * ```php
+ * $service->loadAuthenticator('Authentication.PrimaryKeySession', [
+ *     'identifier' => [
+ *         'className' => 'Authentication.Token',
+ *         'tokenField' => 'uuid',
+ *         'dataField' => 'key',
+ *         'resolver' => [
+ *             'className' => 'Authentication.Orm',
+ *             'userModel' => 'Members',
+ *         ],
+ *     ],
+ * ]);
+ * ```
  */
 class PrimaryKeySessionAuthenticator extends SessionAuthenticator
 {
     /**
-     * @param \Authentication\Identifier\IdentifierInterface|null $identifier
-     * @param array<string, mixed> $config
+     * Default config for this object.
+     *
+     * - `identifierKey` The key used when passing the ID to the identifier.
+     * - `idField` The field on the user entity that contains the primary key.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $_defaultConfig = [
+        'fields' => [],
+        'sessionKey' => 'Auth',
+        'impersonateSessionKey' => 'AuthImpersonate',
+        'identify' => false,
+        'identityAttribute' => 'identity',
+        'identifierKey' => 'key',
+        'idField' => 'id',
+    ];
+
+    /**
+     * Constructor
+     *
+     * Bypasses SessionAuthenticator's default PasswordIdentifier creation
+     * to allow lazy initialization of the TokenIdentifier in getIdentifier().
+     *
+     * @param \Authentication\Identifier\IdentifierInterface|null $identifier Identifier instance.
+     * @param array<string, mixed> $config Configuration settings.
      */
     public function __construct(?IdentifierInterface $identifier, array $config = [])
     {
-        $config += [
-            'identifierKey' => 'key',
-            'idField' => 'id',
-        ];
+        $this->_identifier = $identifier;
+        $this->setConfig($config);
+    }
 
-        parent::__construct($identifier, $config);
+    /**
+     * Gets the identifier.
+     *
+     * If no identifier was explicitly configured, creates a default TokenIdentifier
+     * configured to look up users by their primary key (`id` field).
+     *
+     * @return \Authentication\Identifier\IdentifierInterface
+     */
+    public function getIdentifier(): IdentifierInterface
+    {
+        if ($this->_identifier === null) {
+            $this->_identifier = IdentifierFactory::create([
+                'className' => 'Authentication.Token',
+                'tokenField' => $this->getConfig('idField'),
+                'dataField' => $this->getConfig('identifierKey'),
+            ]);
+        }
+
+        return $this->_identifier;
     }
 
     /**

--- a/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
@@ -67,7 +67,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase
     }
 
     /**
-     * Test authentication
+     * Test authentication with explicit identifier
      *
      * @return void
      */
@@ -87,6 +87,63 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(Result::SUCCESS, $result->getStatus());
+    }
+
+    /**
+     * Test authentication works with default identifier (no explicit configuration)
+     *
+     * @return void
+     */
+    public function testAuthenticateSuccessWithDefaultIdentifier()
+    {
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+
+        $this->sessionMock->expects($this->once())
+            ->method('read')
+            ->with('Auth')
+            ->willReturn(1);
+
+        $request = $request->withAttribute('session', $this->sessionMock);
+
+        // No identifier passed - should use the default TokenIdentifier
+        $authenticator = new PrimaryKeySessionAuthenticator(null);
+        $result = $authenticator->authenticate($request);
+
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertSame(Result::SUCCESS, $result->getStatus());
+    }
+
+    /**
+     * Test getIdentifier returns default TokenIdentifier when none configured
+     *
+     * @return void
+     */
+    public function testGetIdentifierReturnsDefaultWhenNotConfigured()
+    {
+        $authenticator = new PrimaryKeySessionAuthenticator(null);
+        $identifier = $authenticator->getIdentifier();
+
+        $this->assertInstanceOf(\Authentication\Identifier\TokenIdentifier::class, $identifier);
+        $this->assertSame('id', $identifier->getConfig('tokenField'));
+        $this->assertSame('key', $identifier->getConfig('dataField'));
+    }
+
+    /**
+     * Test custom idField/identifierKey config propagates to default identifier
+     *
+     * @return void
+     */
+    public function testGetIdentifierUsesCustomConfig()
+    {
+        $authenticator = new PrimaryKeySessionAuthenticator(null, [
+            'idField' => 'uuid',
+            'identifierKey' => 'token',
+        ]);
+        $identifier = $authenticator->getIdentifier();
+
+        $this->assertInstanceOf(\Authentication\Identifier\TokenIdentifier::class, $identifier);
+        $this->assertSame('uuid', $identifier->getConfig('tokenField'));
+        $this->assertSame('token', $identifier->getConfig('dataField'));
     }
 
     /**

--- a/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/PrimaryKeySessionAuthenticatorTest.php
@@ -20,6 +20,7 @@ use ArrayObject;
 use Authentication\Authenticator\PrimaryKeySessionAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierFactory;
+use Authentication\Identifier\TokenIdentifier;
 use Cake\Http\Exception\UnauthorizedException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
@@ -123,7 +124,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase
         $authenticator = new PrimaryKeySessionAuthenticator(null);
         $identifier = $authenticator->getIdentifier();
 
-        $this->assertInstanceOf(\Authentication\Identifier\TokenIdentifier::class, $identifier);
+        $this->assertInstanceOf(TokenIdentifier::class, $identifier);
         $this->assertSame('id', $identifier->getConfig('tokenField'));
         $this->assertSame('key', $identifier->getConfig('dataField'));
     }
@@ -141,7 +142,7 @@ class PrimaryKeySessionAuthenticatorTest extends TestCase
         ]);
         $identifier = $authenticator->getIdentifier();
 
-        $this->assertInstanceOf(\Authentication\Identifier\TokenIdentifier::class, $identifier);
+        $this->assertInstanceOf(TokenIdentifier::class, $identifier);
         $this->assertSame('uuid', $identifier->getConfig('tokenField'));
         $this->assertSame('token', $identifier->getConfig('dataField'));
     }


### PR DESCRIPTION
## Summary

`PrimaryKeySessionAuthenticator` now provides a default `TokenIdentifier` that works out of the box, eliminating the need for explicit configuration in most cases.

### The Problem

Currently, using `PrimaryKeySessionAuthenticator` requires understanding the internal field mapping between the authenticator and identifier:

```php
$service->loadAuthenticator('Authentication.PrimaryKeySession', [
    'identifier' => [
        'className' => 'Authentication.Token',
        'tokenField' => 'id',
        'dataField' => 'key',
    ],
]);
```

The field names don't align intuitively:
- `identifierKey` (authenticator) ↔ `dataField` (identifier)
- `idField` (authenticator) ↔ `tokenField` (identifier)

### The Solution (Option 1 - Implemented)

Override `getIdentifier()` to lazily create a default `TokenIdentifier` with matching configuration:

```php
// Now works without any configuration!
$service->loadAuthenticator('Authentication.PrimaryKeySession');
```

Custom configuration is still fully supported when needed.

### Alternative Approaches Considered

**Option 2: Align the naming**

Rename the config keys to use consistent terminology across authenticator and identifier. This would improve discoverability but still require explicit configuration.

**Option 3: Change defaults on PrimaryKeySession side**

Change `identifierKey` default from `'key'` to `'id'`, reducing the configuration needed. However, this still requires understanding which fields to configure.

### Why Option 1?

- Zero configuration for the common case (looking up users by `id`)
- Follows the existing pattern in `SessionAuthenticator` (which provides a default `PasswordIdentifier`)
- Custom identifiers still work exactly as before
- The `idField` and `identifierKey` config options automatically propagate to the default identifier

## Test Plan

- [x] Existing tests still pass
- [x] New test: `testAuthenticateSuccessWithDefaultIdentifier` - verifies authentication works without explicit identifier
- [x] New test: `testGetIdentifierReturnsDefaultWhenNotConfigured` - verifies default TokenIdentifier is created
- [x] New test: `testGetIdentifierUsesCustomConfig` - verifies custom `idField`/`identifierKey` propagates correctly