### PR TITLE
Fix remaining identifier config doc examples

### DIFF
--- a/docs/en/authenticators.md
+++ b/docs/en/authenticators.md
@@ -536,8 +536,10 @@ $service = new AuthenticationService();
 // Define identifiers
 $passwordIdentifier = [
     'className' => 'Authentication.Password',
-    'username' => 'email',
-    'password' => 'password'
+    'fields' => [
+        'username' => 'email',
+        'password' => 'password',
+    ],
 ];
 
 // Load the authenticators leaving Basic as the last one.

--- a/docs/en/migration-from-the-authcomponent.md
+++ b/docs/en/migration-from-the-authcomponent.md
@@ -134,14 +134,13 @@ You’ll now have to configure it this way:
 $service = new AuthenticationService();
 
 // Define identifier
- $passwordIdentifier = [
-     'Authentication.Password' => [
-         'fields' => [
-             'username' => 'email',
-             'password' => 'password'
-         ]
-     ],
- ];
+$passwordIdentifier = [
+    'className' => 'Authentication.Password',
+    'fields' => [
+        'username' => 'email',
+        'password' => 'password',
+    ],
+];
 
 // Load the authenticators. Session should be first.
 $service->loadAuthenticator('Authentication.Session');
@@ -159,15 +158,14 @@ $service = new AuthenticationService();
 
 // Define identifier
 $passwordIdentifier = [
-    'Authentication.Password' => [
-         'resolver' => [
-            'className' => 'Authentication.Orm',
-            'userModel' => 'Employees',
-        ],
-        'fields' => [
-            'username' => 'email',
-            'password' => 'password'
-        ]
+    'className' => 'Authentication.Password',
+    'resolver' => [
+        'className' => 'Authentication.Orm',
+        'userModel' => 'Employees',
+    ],
+    'fields' => [
+        'username' => 'email',
+        'password' => 'password',
     ],
 ];
 ```

--- a/docs/en/password-hashers.md
+++ b/docs/en/password-hashers.md
@@ -38,19 +38,18 @@ fallback hasher as follows:
 
 ```php
 $passwordIdentifier = [
-    'Authentication.Password' => [
-        // Other config options
-        'passwordHasher' => [
-            'className' => 'Authentication.Fallback',
-            'hashers' => [
-                'Authentication.Default',
-                [
-                    'className' => 'Authentication.Legacy',
-                    'hashType' => 'md5',
-                    'salt' => false, // turn off default usage of salt
-                ],
-            ]
-        ]
+    'className' => 'Authentication.Password',
+    // Other config options
+    'passwordHasher' => [
+        'className' => 'Authentication.Fallback',
+        'hashers' => [
+            'Authentication.Default',
+            [
+                'className' => 'Authentication.Legacy',
+                'hashType' => 'md5',
+                'salt' => false, // turn off default usage of salt
+            ],
+        ],
     ],
 ];
 ```


### PR DESCRIPTION
## Summary
Follow up #784 by fixing the remaining old identifier config examples and correcting the malformed Authentication.Password example in authenticators.md.

## Changes
- update the remaining nested Authentication.Password examples in migration docs
- update the remaining nested Authentication.Password example in password hasher docs
- restore the required fields nesting in the authenticators.md example