### PR TITLE
Fix docs indentation in auth service example

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -84,10 +84,10 @@ public function getAuthenticationService(ServerRequestInterface $request): Authe
     // Define where users should be redirected to when they are not authenticated
     $service->setConfig([
         'unauthenticatedRedirect' => [
-                'prefix' => false,
-                'plugin' => false,
-                'controller' => 'Users',
-                'action' => 'login',
+            'prefix' => false,
+            'plugin' => false,
+            'controller' => 'Users',
+            'action' => 'login',
         ],
         'queryParam' => 'redirect',
     ]);


### PR DESCRIPTION
## Summary
- fix the over-indented unauthenticatedRedirect array in docs/en/index.md
- keep the example aligned with the surrounding AuthenticationService docs

## Notes
- scanned the repo for similar indentation issues and only this docs snippet needed correction