### PR TITLE
Add redirectAfterLogin() helper

### DIFF
--- a/docs/en/authentication-component.md
+++ b/docs/en/authentication-component.md
@@ -121,3 +121,34 @@ option or by calling `disableIdentityCheck` from the controller's `beforeFilter(
 ``` php
 $this->Authentication->disableIdentityCheck();
 ```
+
+## Redirecting after login
+
+For the common post-login redirect flow, use `redirectAfterLogin()`:
+
+``` php
+public function login(): ?\Cake\Http\Response
+{
+    $result = $this->Authentication->getResult();
+
+    if ($result && $result->isValid()) {
+        return $this->Authentication->redirectAfterLogin('/home');
+    }
+
+    return null;
+}
+```
+
+This uses the plugin's validated login redirect target from the current
+request when available and falls back to the default you provide.
+
+If you need to inspect the validated target before redirecting, use
+`getLoginRedirect()` instead:
+
+``` php
+$target = $this->Authentication->getLoginRedirect('/home');
+return $this->redirect($target);
+```
+
+Avoid reading raw `redirect` query string parameters and passing them directly
+to the controller's `redirect()` method.

--- a/docs/en/authentication-component.md
+++ b/docs/en/authentication-component.md
@@ -126,7 +126,7 @@ $this->Authentication->disableIdentityCheck();
 
 For the common post-login redirect flow, use `redirectAfterLogin()`:
 
-``` php
+```php
 public function login(): ?\Cake\Http\Response
 {
     $result = $this->Authentication->getResult();
@@ -145,7 +145,7 @@ request when available and falls back to the default you provide.
 If you need to inspect the validated target before redirecting, use
 `getLoginRedirect()` instead:
 
-``` php
+```php
 $target = $this->Authentication->getLoginRedirect('/home');
 return $this->redirect($target);
 ```

--- a/docs/en/authenticators.md
+++ b/docs/en/authenticators.md
@@ -581,8 +581,8 @@ $service->setConfig([
 ]);
 ```
 
-Then in your controller's login method you can use `getLoginRedirect()` to get
-the redirect target safely from the query string parameter:
+Then in your controller's login method you can use
+`redirectAfterLogin()` for the common safe post-login redirect flow:
 
 ``` php
 public function login(): ?\Cake\Http\Response
@@ -591,18 +591,20 @@ public function login(): ?\Cake\Http\Response
 
     // Regardless of POST or GET, redirect if user is logged in
     if ($result->isValid()) {
-        // Use the redirect parameter if present.
-        $target = $this->Authentication->getLoginRedirect();
-        if (!$target) {
-            $target = ['controller' => 'Pages', 'action' => 'display', 'home'];
-        }
-
-        return $this->redirect($target);
+        return $this->Authentication->redirectAfterLogin([
+            'controller' => 'Pages',
+            'action' => 'display',
+            'home',
+        ]);
     }
 
     return null;
 }
 ```
+
+If you need to inspect the validated target before redirecting, you can still
+use `getLoginRedirect()` directly and handle the response yourself. Avoid
+passing raw query string parameters to the controller's `redirect()` method.
 
 ## Having Multiple Authentication Flows
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -173,9 +173,7 @@ public function login(): ?\Cake\Http\Response
     $result = $this->Authentication->getResult();
     // If the user is logged in send them away.
     if ($result && $result->isValid()) {
-        $target = $this->Authentication->getLoginRedirect() ?? '/home';
-
-        return $this->redirect($target);
+        return $this->Authentication->redirectAfterLogin('/home');
     }
     if ($this->request->is('post')) {
         $this->Flash->error('Invalid username or password');

--- a/docs/en/migration-from-the-authcomponent.md
+++ b/docs/en/migration-from-the-authcomponent.md
@@ -288,8 +288,8 @@ $service->setConfig([
 ]);
 ```
 
-Then in your controller's login method you can use `getLoginRedirect()` to get
-the redirect target safely from the query string parameter:
+Then in your controller's login method you can use
+`redirectAfterLogin()` for the common safe post-login redirect flow:
 
 ``` php
 public function login(): ?\Cake\Http\Response
@@ -298,18 +298,19 @@ public function login(): ?\Cake\Http\Response
 
     // Regardless of POST or GET, redirect if user is logged in
     if ($result->isValid()) {
-        // Use the redirect parameter if present.
-        $target = $this->Authentication->getLoginRedirect();
-        if (!$target) {
-            $target = ['controller' => 'Pages', 'action' => 'display', 'home'];
-        }
-
-        return $this->redirect($target);
+        return $this->Authentication->redirectAfterLogin([
+            'controller' => 'Pages',
+            'action' => 'display',
+            'home',
+        ]);
     }
 
     return null;
 }
 ```
+
+If you need to inspect the validated target before redirecting, you can still
+use `getLoginRedirect()` directly and then call `redirect()` yourself.
 
 ## Migrating Hashing Upgrade Logic
 

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -379,15 +379,12 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      * controller's redirect method so applications can use the plugin's
      * existing safe redirect parsing without manually reading query params.
      *
-     * @param array|string|null $default Default URL to use when no valid login redirect is available.
+     * @param array|string $default Default URL to use when no valid login redirect is available.
      * @return \Cake\Http\Response|null
      */
-    public function redirectAfterLogin(array|string|null $default = '/'): ?Response
+    public function redirectAfterLogin(array|string $default = '/'): ?Response
     {
         $target = $this->getLoginRedirect($default) ?? $default;
-        if ($target === null) {
-            return null;
-        }
 
         return $this->getController()->redirect($target);
     }

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -29,6 +29,7 @@ use Authentication\IdentityInterface;
 use Cake\Controller\Component;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
+use Cake\Http\Response;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Exception;
@@ -368,6 +369,27 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
         }
 
         return $this->getAuthenticationService()->getLoginRedirect($this->getController()->getRequest()) ?? $default;
+    }
+
+    /**
+     * Redirect after a successful login using the validated login redirect
+     * target from the current request when available.
+     *
+     * This is a convenience wrapper around `getLoginRedirect()` plus the
+     * controller's redirect method so applications can use the plugin's
+     * existing safe redirect parsing without manually reading query params.
+     *
+     * @param array|string|null $default Default URL to use when no valid login redirect is available.
+     * @return \Cake\Http\Response|null
+     */
+    public function redirectAfterLogin(array|string|null $default = '/'): ?Response
+    {
+        $target = $this->getLoginRedirect($default) ?? $default;
+        if ($target === null) {
+            return null;
+        }
+
+        return $this->getController()->redirect($target);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -420,7 +420,7 @@ class AuthenticationComponentTest extends TestCase
         $component = new AuthenticationComponent($registry);
 
         $response = $component->redirectAfterLogin($url);
-        $this->assertSame('/ok/path?value=key', $response?->getHeaderLine('Location'));
+        $this->assertSame('/cakephp/ok/path?value=key', $response?->getHeaderLine('Location'));
 
         Configure::delete('App.base');
     }

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -398,6 +398,84 @@ class AuthenticationComponentTest extends TestCase
     }
 
     /**
+     * testRedirectAfterLogin
+     *
+     * @return void
+     */
+    public function testRedirectAfterLogin(): void
+    {
+        Configure::write('App.base', '/cakephp');
+        $url = ['controller' => 'Users', 'action' => 'dashboard'];
+        Router::createRouteBuilder('/')
+            ->connect('/dashboard', $url);
+
+        $this->service->setConfig('queryParam', 'redirect');
+        $request = $this->request
+            ->withAttribute('identity', $this->identity)
+            ->withAttribute('authentication', $this->service)
+            ->withQueryParams(['redirect' => 'ok/path?value=key']);
+
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $response = $component->redirectAfterLogin($url);
+        $this->assertSame('/ok/path?value=key', $response?->getHeaderLine('Location'));
+
+        Configure::delete('App.base');
+    }
+
+    /**
+     * testRedirectAfterLoginFallsBackToDefaultForAbsoluteUrls
+     *
+     * @return void
+     */
+    public function testRedirectAfterLoginFallsBackToDefaultForAbsoluteUrls(): void
+    {
+        $url = ['controller' => 'Users', 'action' => 'dashboard'];
+        Router::createRouteBuilder('/')
+            ->connect('/dashboard', $url);
+
+        $this->service->setConfig('queryParam', 'redirect');
+        $request = $this->request
+            ->withAttribute('identity', $this->identity)
+            ->withAttribute('authentication', $this->service)
+            ->withQueryParams(['redirect' => 'https://evil.example/phish']);
+
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $response = $component->redirectAfterLogin($url);
+        $this->assertSame('/dashboard', $response?->getHeaderLine('Location'));
+    }
+
+    /**
+     * testRedirectAfterLoginFallsBackToDefaultForProtocolRelativeUrls
+     *
+     * @return void
+     */
+    public function testRedirectAfterLoginFallsBackToDefaultForProtocolRelativeUrls(): void
+    {
+        $url = ['controller' => 'Users', 'action' => 'dashboard'];
+        Router::createRouteBuilder('/')
+            ->connect('/dashboard', $url);
+
+        $this->service->setConfig('queryParam', 'redirect');
+        $request = $this->request
+            ->withAttribute('identity', $this->identity)
+            ->withAttribute('authentication', $this->service)
+            ->withQueryParams(['redirect' => '//evil.example/phish']);
+
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $response = $component->redirectAfterLogin($url);
+        $this->assertSame('/dashboard', $response?->getHeaderLine('Location'));
+    }
+
+    /**
      * testAfterIdentifyEvent
      *
      * @return void

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -420,7 +420,7 @@ class AuthenticationComponentTest extends TestCase
         $component = new AuthenticationComponent($registry);
 
         $response = $component->redirectAfterLogin($url);
-        $this->assertSame('/cakephp/ok/path?value=key', $response?->getHeaderLine('Location'));
+        $this->assertSame(Router::url('/ok/path?value=key'), $response?->getHeaderLine('Location'));
 
         Configure::delete('App.base');
     }


### PR DESCRIPTION
## Summary

This adds a small controller-level helper to make the safe post-login redirect path the obvious one:

```php
return $this->Authentication->redirectAfterLogin('/dashboard');
```

Internally this builds on the existing safe redirect parsing already present in the plugin via `AuthenticationService::getLoginRedirect()` and `AuthenticationComponent::getLoginRedirect()`.

## Why

The plugin already does the hard part correctly:

- `AuthenticationService::getLoginRedirect()` rejects redirect targets with a `scheme` or `host`
- it normalizes local paths
- it applies optional redirect-loop validation

The gap is ergonomics.

In real applications, controller code often ends up doing this instead:

```php
$redirect = $this->request->getQuery('redirect', '/dashboard');
return $this->redirect($redirect);
```

or this:

```php
$redirect = $this->Authentication->getLoginRedirect('/dashboard') ?? '/dashboard';
return $this->redirect($redirect);
```

The second version is safe, but it is a two-step pattern that is easy to bypass or forget. A first-class helper makes the secure path shorter and more discoverable.

## What this adds

This PR adds:

```php
AuthenticationComponent::redirectAfterLogin(array|string|null $default = '/')
```

Behavior:

1. Resolve the validated local redirect target using existing logic: `getLoginRedirect($default)`
2. Fallback to `$default` when no valid redirect is available
3. Return the controller redirect response directly

Example:

```php
if ($result->isValid()) {
    return $this->Authentication->redirectAfterLogin('/dashboard');
}
```

We could release this as a new minor.