### PR TITLE
Add AuthenticationComponent::replaceIdentity()

### DIFF
--- a/docs/en/authentication-component.md
+++ b/docs/en/authentication-component.md
@@ -102,6 +102,60 @@ The result returned will contain an array like this:
 > context you're working in you'll have to use these instances from now on if you
 > want to continue to work with the modified response and request objects.
 
+## Replacing the current identity
+
+Use `setIdentity()` to change which user is logged in (e.g. after registration
+or social-login first-touch). It clears all persisted identity data and writes
+the new identity through every persisting authenticator:
+
+```php
+$this->Authentication->setIdentity($user);
+```
+
+> [!WARNING]
+> `setIdentity()` ends an active impersonation session by default, because it
+> goes through `clearIdentity()` first, which calls `stopImpersonating()` on
+> impersonation-aware authenticators. See the two methods below for the
+> non-default cases.
+
+### Refresh the active identity for the current request only
+
+When you only need to swap the in-request identity (for example to attach
+eager-loaded associations or computed flags in `beforeFilter()`) without
+touching the session or persistence, use `replaceIdentity()`:
+
+```php
+// AppController::beforeFilter()
+$identity = $this->Authentication->getIdentity();
+if ($identity && !$identity->some_association) {
+    $reloaded = $this->fetchTable('Users')
+        ->get($identity->getIdentifier(), finder: 'fullProfile');
+    $this->Authentication->replaceIdentity($reloaded);
+}
+```
+
+This rewrites only the request attribute. The session is not touched, so an
+active impersonation is preserved and no privilege-escalation side effects
+(like session rotation) occur.
+
+### Persist a refreshed identity while impersonating
+
+If the refresh has to survive into subsequent requests but you still want to
+keep an active impersonation alive, pass `preserveImpersonation: true` to
+`setIdentity()`:
+
+```php
+$this->Authentication->setIdentity($reloaded, preserveImpersonation: true);
+```
+
+The new identity is persisted into the session as usual, but the
+impersonation slot (`AuthImpersonate`) and the active authenticator are left
+intact. Note that this also skips the session rotation that the default
+`setIdentity()` flow performs - it is a refresh, not a privilege transition,
+so do not use it for login or role changes.
+
+See [User Impersonation](impersonation.md) for the broader context.
+
 ## Configure Automatic Identity Checks
 
 By default `AuthenticationComponent` will automatically enforce an identity to

--- a/docs/en/authentication-component.md
+++ b/docs/en/authentication-component.md
@@ -134,7 +134,7 @@ if ($identity && !$identity->some_association) {
 }
 ```
 
-This rewrites only the request attribute. The session is not touched, so an
+This rewrites only the request attribute. The session is not modified, so an
 active impersonation is preserved and no privilege-escalation side effects
 (like session rotation) occur.
 

--- a/docs/en/authentication-component.md
+++ b/docs/en/authentication-component.md
@@ -115,8 +115,8 @@ $this->Authentication->setIdentity($user);
 > [!WARNING]
 > `setIdentity()` ends an active impersonation session by default, because it
 > goes through `clearIdentity()` first, which calls `stopImpersonating()` on
-> impersonation-aware authenticators. See the two methods below for the
-> non-default cases.
+> impersonation-aware authenticators. Use `replaceIdentity()` below for the
+> request-only refresh case.
 
 ### Refresh the active identity for the current request only
 
@@ -137,22 +137,6 @@ if ($identity && !$identity->some_association) {
 This rewrites only the request attribute. The session is not modified, so an
 active impersonation is preserved and no privilege-escalation side effects
 (like session rotation) occur.
-
-### Persist a refreshed identity while impersonating
-
-If the refresh has to survive into subsequent requests but you still want to
-keep an active impersonation alive, pass `preserveImpersonation: true` to
-`setIdentity()`:
-
-```php
-$this->Authentication->setIdentity($reloaded, preserveImpersonation: true);
-```
-
-The new identity is persisted into the session as usual, but the
-impersonation slot (`AuthImpersonate`) and the active authenticator are left
-intact. Note that this also skips the session rotation that the default
-`setIdentity()` flow performs - it is a refresh, not a privilege transition,
-so do not use it for login or role changes.
 
 See [User Impersonation](impersonation.md) for the broader context.
 

--- a/docs/en/impersonation.md
+++ b/docs/en/impersonation.md
@@ -73,17 +73,11 @@ There are a few limitations to impersonation.
     code path that swaps the persisted identity will revert to the original
     user.
 
-    To refresh the active identity without disturbing impersonation, use one
-    of the dedicated methods on `AuthenticationComponent`:
-
-    - `replaceIdentity($identity)` updates the in-request identity attribute
-      only. The session is not touched. Use this for the common
-      `beforeFilter()` case of attaching eager-loaded associations to the
-      active user for the rest of the request.
-    - `setIdentity($identity, preserveImpersonation: true)` persists the new
-      identity into the session like the default flow, but keeps the
-      impersonation slot intact. Use this when the refresh has to survive
-      into subsequent requests.
+    To refresh the active identity without disturbing impersonation, use
+    `replaceIdentity($identity)` on `AuthenticationComponent`. It updates the
+    in-request identity attribute only - the session is not touched. Use this
+    for the common `beforeFilter()` case of attaching eager-loaded
+    associations to the active user for the rest of the request.
 
     See [Replacing the current identity](authentication-component.md#replacing-the-current-identity)
     for examples.

--- a/docs/en/impersonation.md
+++ b/docs/en/impersonation.md
@@ -67,3 +67,23 @@ There are a few limitations to impersonation.
 1. Your application must be using the `Session` authenticator.
 2. You cannot impersonate another user while impersonation is active. Instead
     you must `stopImpersonating()` and then start it again.
+3. Calling `setIdentity()` or `clearIdentity()` (and therefore `logout()`)
+    ends impersonation by default. The service's `clearIdentity()` actively
+    calls `stopImpersonating()` on impersonation-aware authenticators, so any
+    code path that swaps the persisted identity will revert to the original
+    user.
+
+    To refresh the active identity without disturbing impersonation, use one
+    of the dedicated methods on `AuthenticationComponent`:
+
+    - `replaceIdentity($identity)` updates the in-request identity attribute
+      only. The session is not touched. Use this for the common
+      `beforeFilter()` case of attaching eager-loaded associations to the
+      active user for the rest of the request.
+    - `setIdentity($identity, preserveImpersonation: true)` persists the new
+      identity into the session like the default flow, but keeps the
+      impersonation slot intact. Use this when the refresh has to survive
+      into subsequent requests.
+
+    See [Replacing the current identity](authentication-component.md#replacing-the-current-identity)
+    for examples.

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -184,26 +184,14 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Message\ResponseInterface $response The response.
-     * @param bool $stopImpersonation Whether to stop an active impersonation
-     *  before clearing each authenticator. Defaults to true (existing
-     *  behavior). Pass false to keep the impersonation session intact - the
-     *  authenticator's `clearIdentity()` is still called, but
-     *  `stopImpersonating()` is not.
      * @return array Return an array containing the request and response objects.
      * @return array{request: \Psr\Http\Message\ServerRequestInterface, response: \Psr\Http\Message\ResponseInterface}
      */
-    public function clearIdentity(
-        ServerRequestInterface $request,
-        ResponseInterface $response,
-        bool $stopImpersonation = true,
-    ): array {
+    public function clearIdentity(ServerRequestInterface $request, ResponseInterface $response): array
+    {
         foreach ($this->authenticators() as $authenticator) {
             if ($authenticator instanceof PersistenceInterface) {
-                if (
-                    $stopImpersonation
-                    && $authenticator instanceof ImpersonationInterface
-                    && $authenticator->isImpersonating($request)
-                ) {
+                if ($authenticator instanceof ImpersonationInterface && $authenticator->isImpersonating($request)) {
                     $stopImpersonationResult = $authenticator->stopImpersonating($request, $response);
                     ['request' => $request, 'response' => $response] = $stopImpersonationResult;
                 }
@@ -211,9 +199,7 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
                 ['request' => $request, 'response' => $response] = $result;
             }
         }
-        if ($stopImpersonation) {
-            $this->_successfulAuthenticator = null;
-        }
+        $this->_successfulAuthenticator = null;
 
         return [
             'request' => $request->withoutAttribute($this->getConfig('identityAttribute')),

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -184,14 +184,26 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param bool $stopImpersonation Whether to stop an active impersonation
+     *  before clearing each authenticator. Defaults to true (existing
+     *  behavior). Pass false to keep the impersonation session intact - the
+     *  authenticator's `clearIdentity()` is still called, but
+     *  `stopImpersonating()` is not.
      * @return array Return an array containing the request and response objects.
      * @return array{request: \Psr\Http\Message\ServerRequestInterface, response: \Psr\Http\Message\ResponseInterface}
      */
-    public function clearIdentity(ServerRequestInterface $request, ResponseInterface $response): array
-    {
+    public function clearIdentity(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        bool $stopImpersonation = true,
+    ): array {
         foreach ($this->authenticators() as $authenticator) {
             if ($authenticator instanceof PersistenceInterface) {
-                if ($authenticator instanceof ImpersonationInterface && $authenticator->isImpersonating($request)) {
+                if (
+                    $stopImpersonation
+                    && $authenticator instanceof ImpersonationInterface
+                    && $authenticator->isImpersonating($request)
+                ) {
                     $stopImpersonationResult = $authenticator->stopImpersonating($request, $response);
                     ['request' => $request, 'response' => $response] = $stopImpersonationResult;
                 }
@@ -199,7 +211,9 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
                 ['request' => $request, 'response' => $response] = $result;
             }
         }
-        $this->_successfulAuthenticator = null;
+        if ($stopImpersonation) {
+            $this->_successfulAuthenticator = null;
+        }
 
         return [
             'request' => $request->withoutAttribute($this->getConfig('identityAttribute')),

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -515,6 +515,10 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
      */
     public function isImpersonating(ServerRequestInterface $request): bool
     {
+        if (!$this->getAuthenticationProvider() instanceof AuthenticatorInterface) {
+            return false;
+        }
+
         $provider = $this->getImpersonationProvider();
 
         return $provider->isImpersonating($request);

--- a/src/AuthenticationServiceInterface.php
+++ b/src/AuthenticationServiceInterface.php
@@ -16,12 +16,14 @@ declare(strict_types=1);
  */
 namespace Authentication;
 
-use ArrayAccess;
 use Authentication\Authenticator\AuthenticatorInterface;
 use Authentication\Authenticator\PersistenceInterface;
 use Authentication\Authenticator\ResultInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * @method \Authentication\IdentityInterface buildIdentity(\ArrayAccess<string, mixed>|array<string, mixed> $identityData) Build an identity object from raw identity data.
+ */
 interface AuthenticationServiceInterface extends PersistenceInterface
 {
     /**
@@ -69,17 +71,6 @@ interface AuthenticationServiceInterface extends PersistenceInterface
      * @return string
      */
     public function getIdentityAttribute(): string;
-
-    /**
-     * Build an identity object from raw identity data.
-     *
-     * If the supplied data is already an `IdentityInterface`, it is returned
-     * unchanged.
-     *
-     * @param \ArrayAccess<string, mixed>|array<string, mixed> $identityData Identity data.
-     * @return \Authentication\IdentityInterface
-     */
-    public function buildIdentity(ArrayAccess|array $identityData): IdentityInterface;
 
     /**
      * Return the URL to redirect unauthenticated users to.

--- a/src/AuthenticationServiceInterface.php
+++ b/src/AuthenticationServiceInterface.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Authentication;
 
+use ArrayAccess;
 use Authentication\Authenticator\AuthenticatorInterface;
 use Authentication\Authenticator\PersistenceInterface;
 use Authentication\Authenticator\ResultInterface;
@@ -68,6 +69,17 @@ interface AuthenticationServiceInterface extends PersistenceInterface
      * @return string
      */
     public function getIdentityAttribute(): string;
+
+    /**
+     * Build an identity object from raw identity data.
+     *
+     * If the supplied data is already an `IdentityInterface`, it is returned
+     * unchanged.
+     *
+     * @param \ArrayAccess<string, mixed>|array<string, mixed> $identityData Identity data.
+     * @return \Authentication\IdentityInterface
+     */
+    public function buildIdentity(ArrayAccess|array $identityData): IdentityInterface;
 
     /**
      * Return the URL to redirect unauthenticated users to.

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -18,7 +18,6 @@ namespace Authentication\Controller\Component;
 
 use ArrayAccess;
 use ArrayObject;
-use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\Authenticator\AuthenticatorInterface;
 use Authentication\Authenticator\ImpersonationInterface;
@@ -300,34 +299,15 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      * is cleared and then set to ensure that privilege escalation
      * and de-escalation include side effects like session rotation.
      *
-     * Pass `$preserveImpersonation = true` to keep an active impersonation
-     * session alive while replacing the identity. The active authenticators'
-     * `clearIdentity()` is still called (so the new identity properly
-     * overwrites the existing one in storage), but the impersonation slot is
-     * left intact. Use this when refreshing the active impersonated user
-     * (for example, attaching eager-loaded associations) without ending the
-     * impersonation.
-     *
      * @param \ArrayAccess|array $identity Identity data to persist.
-     * @param bool $preserveImpersonation Whether to keep an active
-     *  impersonation alive while replacing the identity. Defaults to false
-     *  (existing behavior).
      * @return $this
      */
-    public function setIdentity(ArrayAccess|array $identity, bool $preserveImpersonation = false)
+    public function setIdentity(ArrayAccess|array $identity)
     {
         $controller = $this->getController();
         $service = $this->getAuthenticationService();
 
-        if ($preserveImpersonation && $service instanceof AuthenticationService) {
-            $service->clearIdentity(
-                $controller->getRequest(),
-                $controller->getResponse(),
-                stopImpersonation: false,
-            );
-        } else {
-            $service->clearIdentity($controller->getRequest(), $controller->getResponse());
-        }
+        $service->clearIdentity($controller->getRequest(), $controller->getResponse());
 
         /** @var array{request: \Cake\Http\ServerRequest, response: \Cake\Http\Response} $result */
         $result = $service->persistIdentity(

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -18,6 +18,7 @@ namespace Authentication\Controller\Component;
 
 use ArrayAccess;
 use ArrayObject;
+use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\Authenticator\AuthenticatorInterface;
 use Authentication\Authenticator\ImpersonationInterface;
@@ -299,15 +300,34 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
      * is cleared and then set to ensure that privilege escalation
      * and de-escalation include side effects like session rotation.
      *
+     * Pass `$preserveImpersonation = true` to keep an active impersonation
+     * session alive while replacing the identity. The active authenticators'
+     * `clearIdentity()` is still called (so the new identity properly
+     * overwrites the existing one in storage), but the impersonation slot is
+     * left intact. Use this when refreshing the active impersonated user
+     * (for example, attaching eager-loaded associations) without ending the
+     * impersonation.
+     *
      * @param \ArrayAccess|array $identity Identity data to persist.
+     * @param bool $preserveImpersonation Whether to keep an active
+     *  impersonation alive while replacing the identity. Defaults to false
+     *  (existing behavior).
      * @return $this
      */
-    public function setIdentity(ArrayAccess|array $identity)
+    public function setIdentity(ArrayAccess|array $identity, bool $preserveImpersonation = false)
     {
         $controller = $this->getController();
         $service = $this->getAuthenticationService();
 
-        $service->clearIdentity($controller->getRequest(), $controller->getResponse());
+        if ($preserveImpersonation && $service instanceof AuthenticationService) {
+            $service->clearIdentity(
+                $controller->getRequest(),
+                $controller->getResponse(),
+                stopImpersonation: false,
+            );
+        } else {
+            $service->clearIdentity($controller->getRequest(), $controller->getResponse());
+        }
 
         /** @var array{request: \Cake\Http\ServerRequest, response: \Cake\Http\Response} $result */
         $result = $service->persistIdentity(

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -323,6 +323,38 @@ class AuthenticationComponent extends Component implements EventDispatcherInterf
     }
 
     /**
+     * Replace the in-request identity object without persisting it.
+     *
+     * Use this when you only need to swap the identity attribute on the
+     * current request - for example, to attach eager-loaded associations
+     * or computed flags to the active user for the rest of the request -
+     * without going through `clearIdentity()` and `persistIdentity()`.
+     *
+     * Unlike `setIdentity()`, this does not touch the session and does not
+     * end an active impersonation, because no authenticator's
+     * `clearIdentity()` is invoked.
+     *
+     * @param \ArrayAccess|array $identity Identity data or an identity object.
+     * @return $this
+     */
+    public function replaceIdentity(ArrayAccess|array $identity)
+    {
+        $controller = $this->getController();
+        $service = $this->getAuthenticationService();
+
+        $identity = $service->buildIdentity($identity);
+
+        $controller->setRequest(
+            $controller->getRequest()->withAttribute(
+                $service->getIdentityAttribute(),
+                $identity,
+            ),
+        );
+
+        return $this;
+    }
+
+    /**
      * Log a user out.
      *
      * Triggers the `Authentication.logout` event.

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -371,6 +371,83 @@ class AuthenticationComponentTest extends TestCase
     }
 
     /**
+     * Ensure setIdentity($identity, preserveImpersonation: true) persists the
+     * new identity into the session but does not end an active impersonation,
+     * unlike the default flow.
+     *
+     * @return void
+     */
+    public function testSetIdentityPreserveImpersonation(): void
+    {
+        $impersonator = new ArrayObject(['username' => 'mariano']);
+        $impersonated = new ArrayObject(['username' => 'larry']);
+        $this->request->getSession()->write('Auth', $impersonator);
+        $this->service->authenticate($this->request);
+        $identity = new Identity($impersonator);
+        $request = $this->request
+            ->withAttribute('identity', $identity)
+            ->withAttribute('authentication', $this->service);
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $component->impersonate($impersonated);
+        $this->assertEquals($impersonated, $controller->getRequest()->getSession()->read('Auth'));
+        $this->assertEquals($impersonator, $controller->getRequest()->getSession()->read('AuthImpersonate'));
+
+        $reloaded = new ArrayObject(['username' => 'larry', 'profile' => 'loaded']);
+        $component->setIdentity($reloaded, preserveImpersonation: true);
+
+        $this->assertSame(
+            $reloaded,
+            $component->getIdentity()->getOriginalData(),
+            'Request identity should reflect the reloaded user.',
+        );
+        $this->assertEquals(
+            $reloaded,
+            $controller->getRequest()->getSession()->read('Auth'),
+            'Session Auth slot must be persisted with the reloaded user.',
+        );
+        $this->assertEquals(
+            $impersonator,
+            $controller->getRequest()->getSession()->read('AuthImpersonate'),
+            'Impersonation must survive setIdentity() when preserveImpersonation is set.',
+        );
+        $this->assertTrue($component->isImpersonating());
+    }
+
+    /**
+     * Ensure that `setIdentity()` with the default behavior still ends an
+     * active impersonation - we do not want to silently change BC.
+     *
+     * @return void
+     */
+    public function testSetIdentityDefaultEndsImpersonation(): void
+    {
+        $impersonator = new ArrayObject(['username' => 'mariano']);
+        $impersonated = new ArrayObject(['username' => 'larry']);
+        $this->request->getSession()->write('Auth', $impersonator);
+        $this->service->authenticate($this->request);
+        $identity = new Identity($impersonator);
+        $request = $this->request
+            ->withAttribute('identity', $identity)
+            ->withAttribute('authentication', $this->service);
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $component->impersonate($impersonated);
+
+        $reloaded = new ArrayObject(['username' => 'larry', 'profile' => 'loaded']);
+        $component->setIdentity($reloaded);
+
+        $this->assertNull(
+            $controller->getRequest()->getSession()->read('AuthImpersonate'),
+            'Default setIdentity() must end an active impersonation.',
+        );
+    }
+
+    /**
      * testGetIdentity
      *
      * @eturn void

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -445,6 +445,7 @@ class AuthenticationComponentTest extends TestCase
             $controller->getRequest()->getSession()->read('AuthImpersonate'),
             'Default setIdentity() must end an active impersonation.',
         );
+        $this->assertFalse($component->isImpersonating());
     }
 
     /**

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -371,52 +371,6 @@ class AuthenticationComponentTest extends TestCase
     }
 
     /**
-     * Ensure setIdentity($identity, preserveImpersonation: true) persists the
-     * new identity into the session but does not end an active impersonation,
-     * unlike the default flow.
-     *
-     * @return void
-     */
-    public function testSetIdentityPreserveImpersonation(): void
-    {
-        $impersonator = new ArrayObject(['username' => 'mariano']);
-        $impersonated = new ArrayObject(['username' => 'larry']);
-        $this->request->getSession()->write('Auth', $impersonator);
-        $this->service->authenticate($this->request);
-        $identity = new Identity($impersonator);
-        $request = $this->request
-            ->withAttribute('identity', $identity)
-            ->withAttribute('authentication', $this->service);
-        $controller = new Controller($request);
-        $registry = new ComponentRegistry($controller);
-        $component = new AuthenticationComponent($registry);
-
-        $component->impersonate($impersonated);
-        $this->assertEquals($impersonated, $controller->getRequest()->getSession()->read('Auth'));
-        $this->assertEquals($impersonator, $controller->getRequest()->getSession()->read('AuthImpersonate'));
-
-        $reloaded = new ArrayObject(['username' => 'larry', 'profile' => 'loaded']);
-        $component->setIdentity($reloaded, preserveImpersonation: true);
-
-        $this->assertSame(
-            $reloaded,
-            $component->getIdentity()->getOriginalData(),
-            'Request identity should reflect the reloaded user.',
-        );
-        $this->assertEquals(
-            $reloaded,
-            $controller->getRequest()->getSession()->read('Auth'),
-            'Session Auth slot must be persisted with the reloaded user.',
-        );
-        $this->assertEquals(
-            $impersonator,
-            $controller->getRequest()->getSession()->read('AuthImpersonate'),
-            'Impersonation must survive setIdentity() when preserveImpersonation is set.',
-        );
-        $this->assertTrue($component->isImpersonating());
-    }
-
-    /**
      * Ensure that `setIdentity()` with the default behavior still ends an
      * active impersonation - we do not want to silently change BC.
      *

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -281,6 +281,96 @@ class AuthenticationComponentTest extends TestCase
     }
 
     /**
+     * Ensure replaceIdentity() swaps the request attribute without
+     * touching the session.
+     *
+     * @return void
+     */
+    public function testReplaceIdentity(): void
+    {
+        $request = $this->request->withAttribute('authentication', $this->service);
+
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $component->replaceIdentity($this->identityData);
+
+        $result = $component->getIdentity();
+        $this->assertInstanceOf(IdentityInterface::class, $result);
+        $this->assertSame($this->identityData, $result->getOriginalData());
+        $this->assertNull(
+            $controller->getRequest()->getSession()->read('Auth'),
+            'Session must not be written by replaceIdentity().',
+        );
+    }
+
+    /**
+     * Test that replaceIdentity() called with an identity instance keeps the
+     * exact instance as the request attribute.
+     *
+     * @return void
+     */
+    public function testReplaceIdentityInstance(): void
+    {
+        $request = $this->request->withAttribute('authentication', $this->service);
+
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $identity = new Identity($this->identityData);
+        $component->replaceIdentity($identity);
+
+        $this->assertSame($identity, $component->getIdentity());
+    }
+
+    /**
+     * Ensure replaceIdentity() does not end an active impersonation,
+     * unlike setIdentity() which clears identity first.
+     *
+     * @return void
+     */
+    public function testReplaceIdentityKeepsImpersonation(): void
+    {
+        $impersonator = new ArrayObject(['username' => 'mariano']);
+        $impersonated = new ArrayObject(['username' => 'larry']);
+        $this->request->getSession()->write('Auth', $impersonator);
+        $this->service->authenticate($this->request);
+        $identity = new Identity($impersonator);
+        $request = $this->request
+            ->withAttribute('identity', $identity)
+            ->withAttribute('authentication', $this->service);
+        $controller = new Controller($request);
+        $registry = new ComponentRegistry($controller);
+        $component = new AuthenticationComponent($registry);
+
+        $component->impersonate($impersonated);
+        $this->assertEquals($impersonated, $controller->getRequest()->getSession()->read('Auth'));
+        $this->assertEquals($impersonator, $controller->getRequest()->getSession()->read('AuthImpersonate'));
+
+        $reloaded = new ArrayObject(['username' => 'larry', 'profile' => 'loaded']);
+        $component->replaceIdentity($reloaded);
+
+        $this->assertSame(
+            $reloaded,
+            $component->getIdentity()->getOriginalData(),
+            'Request identity should reflect the reloaded user.',
+        );
+        $this->assertEquals(
+            $impersonated,
+            $controller->getRequest()->getSession()->read('Auth'),
+            'Session Auth slot must be untouched by replaceIdentity().',
+        );
+        $this->assertEquals(
+            $impersonator,
+            $controller->getRequest()->getSession()->read('AuthImpersonate'),
+            'Impersonation must survive replaceIdentity().',
+        );
+        $this->assertTrue($component->isImpersonating());
+    }
+
+    /**
      * testGetIdentity
      *
      * @eturn void


### PR DESCRIPTION
## Summary

Adds `AuthenticationComponent::replaceIdentity()` for swapping the in-request identity attribute without going through `clearIdentity()` / `persistIdentity()`.

## Motivation

A common pattern in apps is to enrich the active user with eager-loaded associations or computed flags in `AppController::beforeFilter()`. Doing this with `setIdentity()` has a surprising side effect: `setIdentity()` calls `clearIdentity()` first, and the service's `clearIdentity()` actively calls `stopImpersonating()` on impersonation-aware authenticators (`AuthenticationService.php` lines 192-200). So a pattern like

```php
if ($user && !$user->some_association) {
    $reloaded = $this->Users->get($user->id, finder: 'fullProfile');
    $this->Authentication->setIdentity($reloaded);
}
```

silently ends impersonation on every request where the association was missing.

`replaceIdentity()` solves this by writing only to the request attribute - no session writes, no `clearIdentity` chain, no impersonation interaction. It mirrors what `withAttribute('identity', new Identity($data))` does, but routes through the service so the configured `identityClass` is honored.

## Changes

- `AuthenticationComponent::replaceIdentity(ArrayAccess|array $identity)` - new method
- `AuthenticationServiceInterface::buildIdentity()` - lifted to the interface so the component can call it without a concrete-type cast (the method already existed on `AuthenticationService`)
- 3 unit tests: array data, identity instance, and the impersonation-survival case
