### PR TITLE
Fix an open redirect weakness in getLoginRedirect()

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -398,8 +398,19 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
         ) {
             return null;
         }
+        $value = (string)$params[$redirectParam];
 
-        $parsed = parse_url((string)$params[$redirectParam]);
+        // In the `Location` header, Browsers normalize \ to /
+        // (see WHATWG URL Standard).
+        // We do the same to prevent injection via \ sequences.
+        $normalized = str_replace('\\', '/', $value);
+
+        // A leading run of `//` or `\\` are rejected
+        if (str_starts_with($normalized, '//')) {
+            return null;
+        }
+
+        $parsed = parse_url($normalized);
         if ($parsed === false) {
             return null;
         }
@@ -407,6 +418,9 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
             return null;
         }
         $parsed += ['path' => '/', 'query' => ''];
+        if (str_contains($parsed['path'], '\\')) {
+            return null;
+        }
         if (strlen($parsed['path']) && $parsed['path'][0] !== '/') {
             $parsed['path'] = '/' . $parsed['path'];
         }

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -822,7 +822,7 @@ class AuthenticationServiceTest extends TestCase
         );
     }
 
-    public function testGetLoginRedirect(): void
+    public function testGetLoginRedirectInvalid(): void
     {
         $service = new AuthenticationService([
             'unauthenticatedRedirect' => '/users/login',
@@ -861,6 +861,39 @@ class AuthenticationServiceTest extends TestCase
         );
         $this->assertSame(
             '/path/with?query=string',
+            $service->getLoginRedirect($request),
+        );
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/login'],
+            ['redirect' => '/\\evil.com'],
+        );
+        $this->assertNull(
+            $service->getLoginRedirect($request),
+        );
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/login'],
+            ['redirect' => '\\/\\evil.com'],
+        );
+        $this->assertNull(
+            $service->getLoginRedirect($request),
+        );
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/login'],
+            ['redirect' => '\\evil.com/path'],
+        );
+        $this->assertSame(
+            '/evil.com/path',
+            $service->getLoginRedirect($request),
+        );
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/login'],
+            ['redirect' => '\\\\evil.com/path'],
+        );
+        $this->assertNull(
             $service->getLoginRedirect($request),
         );
     }


### PR DESCRIPTION
Because of how browsers handle the `Location` header, values beginning with `\` can be leveraged to create redirect targets on other domains.

Thanks to Volker Dusch and the PHP Ecosystem security team for reporting this.