### PR TITLE
Fix an open redirect weakness in getLoginRedirect()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,11 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
+        "policy": {
+            "advisories": {
+                "ignore": ["PKSA-y2cr-5h3j-g3ys"]
+            }
+        },
         "sort-packages": true
     },
     "scripts": {

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -459,8 +459,19 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
         ) {
             return null;
         }
+        $value = (string)$params[$redirectParam];
 
-        $parsed = parse_url($params[$redirectParam]);
+        // In the `Location` header, Browsers normalize \ to /
+        // (see WHATWG URL Standard).
+        // We do the same to prevent injection via \ sequences.
+        $normalized = str_replace('\\', '/', $value);
+
+        // A leading run of `//` or `\\` are rejected
+        if (str_starts_with($normalized, '//')) {
+            return null;
+        }
+
+        $parsed = parse_url($normalized);
         if ($parsed === false) {
             return null;
         }
@@ -468,6 +479,9 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
             return null;
         }
         $parsed += ['path' => '/', 'query' => ''];
+        if (str_contains($parsed['path'], '\\')) {
+            return null;
+        }
         if (strlen($parsed['path']) && $parsed['path'][0] !== '/') {
             $parsed['path'] = "/{$parsed['path']}";
         }

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -915,7 +915,7 @@ class AuthenticationServiceTest extends TestCase
         );
     }
 
-    public function testGetLoginRedirect()
+    public function testGetLoginRedirectInvalid()
     {
         $service = new AuthenticationService([
             'unauthenticatedRedirect' => '/users/login',
@@ -954,6 +954,39 @@ class AuthenticationServiceTest extends TestCase
         );
         $this->assertSame(
             '/path/with?query=string',
+            $service->getLoginRedirect($request),
+        );
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/login'],
+            ['redirect' => '/\\evil.com'],
+        );
+        $this->assertNull(
+            $service->getLoginRedirect($request),
+        );
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/login'],
+            ['redirect' => '\\/\\evil.com'],
+        );
+        $this->assertNull(
+            $service->getLoginRedirect($request),
+        );
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/login'],
+            ['redirect' => '\\evil.com/path'],
+        );
+        $this->assertSame(
+            '/evil.com/path',
+            $service->getLoginRedirect($request),
+        );
+
+        $request = ServerRequestFactory::fromGlobals(
+            ['REQUEST_URI' => '/login'],
+            ['redirect' => '\\\\evil.com/path'],
+        );
+        $this->assertNull(
             $service->getLoginRedirect($request),
         );
     }


### PR DESCRIPTION
Backport of #795 to 3.x

Because of how browsers handle the `Location` header, values beginning with `\` can be leveraged to create redirect targets on other domains.

Thanks to Volker Dusch and the PHP Ecosystem security team for reporting this.