### PR TITLE
Return null from getIdentificationProvider() for identifier-less authenticators

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -20,6 +20,7 @@ use ArrayAccess;
 use Authentication\Authenticator\AuthenticatorCollection;
 use Authentication\Authenticator\AuthenticatorInterface;
 use Authentication\Authenticator\ImpersonationInterface;
+use Authentication\Authenticator\MissingIdentifierException;
 use Authentication\Authenticator\PersistenceInterface;
 use Authentication\Authenticator\ResultInterface;
 use Authentication\Authenticator\StatelessInterface;
@@ -257,7 +258,16 @@ class AuthenticationService implements AuthenticationServiceInterface, Impersona
             return null;
         }
 
-        return $this->_successfulAuthenticator->getIdentifier();
+        try {
+            return $this->_successfulAuthenticator->getIdentifier();
+        } catch (MissingIdentifierException) {
+            // Authenticators may operate without an identifier (e.g. session
+            // based authentication with `identify` disabled), in which case
+            // getIdentifier() throws. There is no identification provider then.
+            // Other runtime failures (e.g. an invalid identifier config) are
+            // intentionally not caught here so they still surface.
+            return null;
+        }
     }
 
     /**

--- a/src/Authenticator/AbstractAuthenticator.php
+++ b/src/Authenticator/AbstractAuthenticator.php
@@ -20,7 +20,6 @@ use Authentication\Identifier\IdentifierInterface;
 use Authentication\Identifier\PasswordIdentifier;
 use Cake\Core\InstanceConfigTrait;
 use Psr\Http\Message\ServerRequestInterface;
-use RuntimeException;
 
 abstract class AbstractAuthenticator implements AuthenticatorInterface
 {
@@ -63,12 +62,12 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface
      * when none was configured, enabling lazy initialization.
      *
      * @return \Authentication\Identifier\IdentifierInterface
-     * @throws \RuntimeException When identifier is null.
+     * @throws \Authentication\Authenticator\MissingIdentifierException When identifier is null.
      */
     public function getIdentifier(): IdentifierInterface
     {
         if (!$this->_identifier instanceof IdentifierInterface) {
-            throw new RuntimeException(
+            throw new MissingIdentifierException(
                 sprintf(
                     'Identifier is required for `%s`. Please provide an identifier instance.',
                     static::class,

--- a/src/Authenticator/MissingIdentifierException.php
+++ b/src/Authenticator/MissingIdentifierException.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authentication\Authenticator;
+
+use RuntimeException;
+
+/**
+ * Thrown when an authenticator is asked for its identifier but none was
+ * configured (and none could be created lazily).
+ *
+ * Extends `RuntimeException` for backwards compatibility with existing catch
+ * blocks; it lets callers distinguish the "no identifier available" case from
+ * other runtime failures such as an invalid identifier configuration.
+ */
+class MissingIdentifierException extends RuntimeException
+{
+}

--- a/src/Authenticator/MissingIdentifierException.php
+++ b/src/Authenticator/MissingIdentifierException.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         4.0.0
+ * @since         4.2.2
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Authentication\Authenticator;

--- a/tests/TestCase/AuthenticationServiceTest.php
+++ b/tests/TestCase/AuthenticationServiceTest.php
@@ -22,6 +22,7 @@ use Authentication\Authenticator\AuthenticationRequiredException;
 use Authentication\Authenticator\AuthenticatorInterface;
 use Authentication\Authenticator\FormAuthenticator;
 use Authentication\Authenticator\Result;
+use Authentication\Authenticator\SessionAuthenticator;
 use Authentication\Identifier\PasswordIdentifier;
 use Authentication\Identity;
 use Authentication\IdentityInterface;
@@ -1326,5 +1327,30 @@ class AuthenticationServiceTest extends TestCase
 
         $authenticator = $service->getAuthenticationProvider();
         $this->assertInstanceOf(FormAuthenticator::class, $authenticator);
+
+        // The lazily created default identifier must still be reported.
+        $this->assertInstanceOf(PasswordIdentifier::class, $service->getIdentificationProvider());
+    }
+
+    /**
+     * Authenticators without an identifier (e.g. the session authenticator with
+     * the default `identify` => false) must report no identification provider
+     * instead of throwing when getIdentificationProvider() is called.
+     *
+     * @return void
+     */
+    public function testGetIdentificationProviderWithoutIdentifier(): void
+    {
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/']);
+        $request->getSession()->write('Auth', ['username' => 'mariano']);
+
+        $service = new AuthenticationService();
+        $service->loadAuthenticator('Authentication.Session');
+
+        $result = $service->authenticate($request);
+        $this->assertTrue($result->isValid());
+
+        $this->assertInstanceOf(SessionAuthenticator::class, $service->getAuthenticationProvider());
+        $this->assertNull($service->getIdentificationProvider());
     }
 }

--- a/tests/TestCase/Authenticator/AbstractAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/AbstractAuthenticatorTest.php
@@ -73,7 +73,7 @@ class AbstractAuthenticatorTest extends TestCase
      */
     public function testGetIdentifierWithoutIdentifierThrows(): void
     {
-        $authenticator = new class (null) extends AbstractAuthenticator {
+        $authenticator = new class extends AbstractAuthenticator {
             public function authenticate($request): Result
             {
                 return new Result([], ResultInterface::SUCCESS);

--- a/tests/TestCase/Authenticator/AbstractAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/AbstractAuthenticatorTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Authentication\Test\TestCase\Authenticator;
 
 use Authentication\Authenticator\AbstractAuthenticator;
+use Authentication\Authenticator\MissingIdentifierException;
 use Authentication\Authenticator\Result;
 use Authentication\Authenticator\ResultInterface;
 use Authentication\Identifier\IdentifierInterface;
@@ -63,5 +64,23 @@ class AbstractAuthenticatorTest extends TestCase
         $authenticator->setIdentifier($otherIdentifier);
 
         $this->assertSame($otherIdentifier, $authenticator->getIdentifier());
+    }
+
+    /**
+     * getIdentifier() throws a MissingIdentifierException when none is set.
+     *
+     * @return void
+     */
+    public function testGetIdentifierWithoutIdentifierThrows(): void
+    {
+        $authenticator = new class (null) extends AbstractAuthenticator {
+            public function authenticate($request): Result
+            {
+                return new Result([], ResultInterface::SUCCESS);
+            }
+        };
+
+        $this->expectException(MissingIdentifierException::class);
+        $authenticator->getIdentifier();
     }
 }


### PR DESCRIPTION
Fixes #179.

## Problem

On 4.x an authenticator's identifier is optional. `AuthenticatorCollection::create()` passes `null` when no `identifier` is configured, and the session authenticator (default `identify` => false) authenticates purely from stored session data, so it legitimately has no identifier.

`AbstractAuthenticator::getIdentifier()` throws in that case. `AuthenticationService::getIdentificationProvider()` called it unconditionally, so the whole request blew up whenever such an authenticator was the successful one:

```
Identifier is required for `Authentication\Authenticator\SessionAuthenticator`. Please provide an identifier instance.
```

This surfaces for any consumer that reads the identification provider after a session based login (the reporter hit it via the TinyAuth DebugKit panel).

## Fix

- Add `MissingIdentifierException` (extends `RuntimeException` for backwards compatibility) thrown by `AbstractAuthenticator::getIdentifier()` when no identifier is available.
- `getIdentificationProvider()` catches exactly that type and returns `null`.

Catching the specific type rather than a bare `RuntimeException`:

- preserves lazy identifier creation in subclasses (`FormAuthenticator`, `CookieAuthenticator`, `JwtAuthenticator`, `TokenAuthenticator`, `PrimaryKeySessionAuthenticator`, ...) whose overridden `getIdentifier()` builds a default identifier on first call, and
- does not mask genuine identifier configuration failures, which still throw a plain `RuntimeException` from `IdentifierFactory`.

## Backwards compatibility

`MissingIdentifierException extends RuntimeException`, so existing `catch (RuntimeException)` blocks and the message are unchanged.
